### PR TITLE
feat: 感情分析モデルの誤分類ベースライン分析（Issue #19 Step B）

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ transformers      # Hugging Face
 bertopic          # トピック抽出
 sentence-transformers  # 文章埋め込み
 langdetect        # 言語検出（非英語レビュー除外）
+transformers-interpret  # モデル解釈性（Integrated Gradients）
 
 # Phase 7: Time Series (Prophet)
 # - prophet           # 時系列予測

--- a/scripts/experiments/analyze_misclassified.py
+++ b/scripts/experiments/analyze_misclassified.py
@@ -1,0 +1,198 @@
+"""
+誤分類分析スクリプト
+
+現行の感情分析モデル（models/best_model）でreviews_10000.csv全件を予測し、
+正解ラベル（voted_up由来のlabel列）と一致しない事例を抽出する。
+
+将来的なモデル改善のベースライン取得が目的。
+
+出力:
+    - data/experiments/sarcasm_baseline/misclassified.csv（最新のみ・上書き）
+    - data/experiments/sarcasm_baseline/summary.csv（全モデルの集計・追記）
+"""
+
+import sys
+import os
+import json
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
+
+import torch
+import pandas as pd
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+
+from src.nlp.dataset import SteamReviewDataset
+from src.nlp.model import load_model
+
+
+def predict_all(
+    model: torch.nn.Module,
+    dataloader: DataLoader,
+    device: str
+) -> tuple[list[int], list[float]]:
+    """全レビューに対して予測を実行"""
+    model.eval()
+    predictions = []
+    confidences = []
+
+    with torch.no_grad():
+        for batch in tqdm(dataloader, desc="予測中"):
+            input_ids = batch['input_ids'].to(device)
+            attention_mask = batch['attention_mask'].to(device)
+
+            logits = model(input_ids=input_ids, attention_mask=attention_mask)
+            probs = torch.softmax(logits, dim=1)
+            preds = torch.argmax(probs, dim=1)
+
+            batch_confidences = probs.gather(1, preds.unsqueeze(1)).squeeze(1)
+
+            predictions.extend(preds.cpu().tolist())
+            confidences.extend(batch_confidences.cpu().tolist())
+
+    return predictions, confidences
+
+
+def label_to_pn(label: int) -> str:
+    """1→P, 0→N に変換"""
+    return 'P' if label == 1 else 'N'
+
+
+def append_summary(summary_path: str, row: dict):
+    """summary.csv に1行追記（同タイムスタンプは重複させない）"""
+    columns = [
+        'model_timestamp', 'dataset', 'seed', 'lr', 'patience', 'dropout',
+        'batch_size', 'accuracy', 'fp', 'fn', 'misclassified',
+        'high_confidence_errors'
+    ]
+
+    if os.path.exists(summary_path):
+        df = pd.read_csv(summary_path)
+        # 同タイムスタンプは上書きせず重複追加防止
+        if (df['model_timestamp'] == row['model_timestamp']).any():
+            print(f"⚠️  既存のmodel_timestamp（{row['model_timestamp']}）が存在するため追記しません")
+            return
+        df = pd.concat([df, pd.DataFrame([row])], ignore_index=True)
+    else:
+        df = pd.DataFrame([row], columns=columns)
+
+    df.to_csv(summary_path, index=False)
+
+
+def main():
+    print("=" * 70)
+    print("誤分類分析: reviews_10000.csv vs models/best_model")
+    print("=" * 70)
+
+    # パス設定
+    input_path = 'data/train/reviews_10000.csv'
+    model_dir = 'models/best_model'
+    output_dir = 'data/experiments/sarcasm_baseline'
+    misclassified_path = os.path.join(output_dir, 'misclassified.csv')
+    summary_path = os.path.join(output_dir, 'summary.csv')
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    # 1. モデルメタデータ読み込み（training_results.jsonから）
+    results_path = os.path.join(model_dir, 'training_results.json')
+    if not os.path.exists(results_path):
+        raise FileNotFoundError(
+            f"training_results.json が見つかりません: {results_path}\n"
+            f"先に make train-sentiment で学習結果を生成してください。"
+        )
+
+    with open(results_path, 'r', encoding='utf-8') as f:
+        training_info = json.load(f)
+
+    print(f"\n[1/4] モデルメタデータ読み込み")
+    print(f"  学習タイムスタンプ: {training_info['timestamp']}")
+    print(f"  ハイパーパラメータ: {training_info['hyperparameters']}")
+
+    # 2. データ読み込み
+    df = pd.read_csv(input_path)
+    df = df.dropna(subset=['review_text']).reset_index(drop=True)
+    print(f"\n[2/4] データ読み込み: {len(df)}件")
+
+    # 3. モデル読み込み・予測
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    print(f"\n[3/4] モデル読み込み・予測 (device={device})")
+    model, tokenizer = load_model(model_dir, device=device)
+
+    dataset = SteamReviewDataset(
+        texts=df['review_text'].tolist(),
+        labels=df['label'].tolist(),
+        tokenizer=tokenizer,
+        max_length=128
+    )
+    dataloader = DataLoader(dataset, batch_size=64, shuffle=False)
+
+    predictions, confidences = predict_all(model, dataloader, device)
+
+    # 4. 誤分類抽出と保存
+    print(f"\n[4/4] 誤分類抽出と保存")
+    df['predicted_label'] = predictions
+    df['confidence'] = confidences
+    df['is_correct'] = df['label'] == df['predicted_label']
+
+    total = len(df)
+    correct = int(df['is_correct'].sum())
+    misclassified_count = total - correct
+    accuracy = correct / total
+
+    fp = int(((df['label'] == 0) & (df['predicted_label'] == 1)).sum())
+    fn = int(((df['label'] == 1) & (df['predicted_label'] == 0)).sum())
+
+    print(f"\n【全体統計】")
+    print(f"  総件数:     {total}")
+    print(f"  正解:       {correct} ({accuracy:.2%})")
+    print(f"  誤分類:     {misclassified_count} ({misclassified_count / total:.2%})")
+    print(f"  FP (NをPと誤認): {fp} ({fp / total:.2%})")
+    print(f"  FN (PをNと誤認): {fn} ({fn / total:.2%})")
+
+    # 誤分類サンプルのCSV出力（P/N・FP/FN形式で軽量化）
+    misclassified_df = df[~df['is_correct']].copy()
+    misclassified_df['actual'] = misclassified_df['label'].apply(label_to_pn)
+    misclassified_df['predicted'] = misclassified_df['predicted_label'].apply(label_to_pn)
+    misclassified_df['error_type'] = misclassified_df.apply(
+        lambda r: 'FP' if r['label'] == 0 else 'FN',
+        axis=1
+    )
+
+    save_cols = ['review_text', 'actual', 'predicted', 'confidence', 'error_type']
+    if 'game_name' in misclassified_df.columns:
+        save_cols.insert(0, 'game_name')
+
+    misclassified_df[save_cols].to_csv(misclassified_path, index=False)
+    print(f"\n✅ 誤分類サンプル保存: {misclassified_path}")
+
+    # 信頼度の分布
+    high_conf_errors = int((misclassified_df['confidence'] >= 0.9).sum())
+    print(f"\n【誤分類の信頼度分布】")
+    print(f"  平均confidence: {misclassified_df['confidence'].mean():.3f}")
+    print(f"  高信頼誤分類 (>= 0.9): {high_conf_errors}件")
+
+    # summary.csv に追記
+    summary_row = {
+        'model_timestamp': training_info['timestamp'],
+        'dataset': training_info['dataset_path'],
+        'seed': training_info['hyperparameters']['random_seed'],
+        'lr': training_info['hyperparameters']['learning_rate'],
+        'patience': training_info['hyperparameters']['patience'],
+        'dropout': 0.3,  # model.pyのデフォルト
+        'batch_size': training_info['hyperparameters']['batch_size'],
+        'accuracy': round(accuracy, 4),
+        'fp': fp,
+        'fn': fn,
+        'misclassified': misclassified_count,
+        'high_confidence_errors': high_conf_errors,
+    }
+    append_summary(summary_path, summary_row)
+    print(f"✅ サマリー追記: {summary_path}")
+
+    print("\n" + "=" * 70)
+    print("分析完了")
+    print("=" * 70)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/experiments/categorize_misclassified.py
+++ b/scripts/experiments/categorize_misclassified.py
@@ -1,19 +1,21 @@
 """
-誤分類サンプルのヒューリスティック自動分類
+誤分類サンプルのヒューリスティックタグ付け
 
-misclassified.csvの各レビューにルールベースでカテゴリを付与する。
-モデルの弱点パターン（皮肉・否定・混合感情など）を傾向把握するための一次分類。
+misclassified.csvの各レビューに、該当する全パターンをタグとして付与する。
+カテゴリ排他方式と異なり、1レビューに複数タグが付与可能。
 
 入力:
     data/experiments/sarcasm_baseline/misclassified.csv
 
 出力:
-    data/experiments/sarcasm_baseline/misclassified_categorized.csv
-    （category列追加・category順 + 各カテゴリ内confidence降順でソート）
+    data/experiments/sarcasm_baseline/misclassified_tagged.csv
+    （tags列・tag_count列を追加・confidence降順でソート）
 """
 
 import os
 import re
+from collections import Counter
+from itertools import combinations
 
 import pandas as pd
 
@@ -24,13 +26,20 @@ NEGATION_WORDS = [
     "won't", "wouldn't", 'nothing', 'nobody', 'nowhere',
 ]
 
-NEGATIVE_WORDS = [
+# 二重否定検出用のネガティブ語
+NEGATIVE_WORDS_FOR_DOUBLE_NEG = [
     'bad', 'awful', 'terrible', 'horrible', 'boring', 'broken',
     'disappointed', 'disappointing', 'wrong', 'useless', 'impossible',
     'worst', 'poor', 'weak', 'dull',
 ]
 
 MIXED_WORDS = ['but', 'however', 'although', 'though', 'despite']
+
+# スラング・口語的なネガティブ表現（標準的なネガティブ語と区別）
+STRONG_NEGATIVE_WORDS = [
+    'bs', 'garbage', 'trash', 'shit', 'crap', 'suck', 'sucks', 'sucked',
+    'cheaters', 'stupid', 'cancer', 'toxic',
+]
 
 RATING_PATTERNS = [
     r'\b0/10\b', r'\b10/10\b', r'★', r'\b100%\b',
@@ -39,17 +48,16 @@ RATING_PATTERNS = [
 
 SLANG_WORDS = ['fr', 'no cap', 'slaps', 'mid', 'ngl', 'based', 'cringe']
 
-# カテゴリ判定の優先順位
-CATEGORY_ORDER = [
-    '二重否定', '単純否定', '混合感情', '評価記号矛盾',
-    'スラング', '全大文字強調', '短文', 'その他',
+# 表示順（集計表示時の順番）
+TAG_ORDER = [
+    '否定語あり', '二重否定構造', '接続詞混合', '強ネガ表現',
+    '評価記号', 'スラング', '全大文字', '短文', '長文',
 ]
 
 
 def _contains_word(text_lower: str, words: list[str]) -> bool:
-    """単語の境界を考慮した部分一致判定"""
+    """単語境界を考慮した部分一致判定"""
     for w in words:
-        # 単語境界で囲んで検索（アポストロフィを含む場合は別処理）
         pattern = r'\b' + re.escape(w) + r'\b'
         if re.search(pattern, text_lower):
             return True
@@ -57,13 +65,12 @@ def _contains_word(text_lower: str, words: list[str]) -> bool:
 
 
 def _has_double_negation(text_lower: str) -> bool:
-    """否定語の近くにネガティブ語があるか（5単語以内）"""
+    """否定語の直後5単語以内にネガティブ語があるか"""
     tokens = re.findall(r"[a-z']+", text_lower)
     negation_indices = [i for i, t in enumerate(tokens) if t in NEGATION_WORDS]
-    negative_set = set(NEGATIVE_WORDS)
+    negative_set = set(NEGATIVE_WORDS_FOR_DOUBLE_NEG)
 
     for idx in negation_indices:
-        # 否定語の直後5単語以内にネガティブ語があるか
         for j in range(idx + 1, min(idx + 6, len(tokens))):
             if tokens[j] in negative_set:
                 return True
@@ -71,119 +78,144 @@ def _has_double_negation(text_lower: str) -> bool:
 
 
 def _is_all_caps(text: str, threshold: float = 0.5) -> bool:
-    """テキストの大文字率が閾値以上か（アルファベットに対する割合）"""
+    """テキストの大文字率が閾値以上か"""
     letters = [c for c in text if c.isalpha()]
-    if len(letters) < 10:  # 短すぎる場合は判定しない
+    if len(letters) < 10:
         return False
     upper_count = sum(1 for c in letters if c.isupper())
     return upper_count / len(letters) >= threshold
 
 
-def classify(text: str) -> str:
-    """1レビューにカテゴリを付与"""
+def assign_tags(text: str) -> list[str]:
+    """1レビューに該当する全タグを付与（マルチラベル）"""
     if not isinstance(text, str) or not text:
-        return 'その他'
+        return []
 
     text_lower = text.lower()
+    tags = []
 
-    # 1. 二重否定（最優先 - 二重否定は意味が反転して肯定になる）
-    if _has_double_negation(text_lower):
-        return '二重否定'
-
-    # 2. 単純否定
+    # 否定関連
     if _contains_word(text_lower, NEGATION_WORDS):
-        return '単純否定'
+        tags.append('否定語あり')
+    if _has_double_negation(text_lower):
+        tags.append('二重否定構造')
 
-    # 3. 混合感情
+    # 接続詞混合
     if _contains_word(text_lower, MIXED_WORDS):
-        return '混合感情'
+        tags.append('接続詞混合')
 
-    # 4. 評価記号矛盾
+    # 強ネガ表現
+    if _contains_word(text_lower, STRONG_NEGATIVE_WORDS):
+        tags.append('強ネガ表現')
+
+    # 評価記号
     for pattern in RATING_PATTERNS:
         if re.search(pattern, text):
-            return '評価記号矛盾'
+            tags.append('評価記号')
+            break
 
-    # 5. スラング
+    # スラング
     if _contains_word(text_lower, SLANG_WORDS):
-        return 'スラング'
+        tags.append('スラング')
 
-    # 6. 全大文字強調
+    # 全大文字強調
     if _is_all_caps(text):
-        return '全大文字強調'
+        tags.append('全大文字')
 
-    # 7. 短文
+    # 長さ
     if len(text) < 50:
-        return '短文'
+        tags.append('短文')
+    elif len(text) >= 300:
+        tags.append('長文')
 
-    return 'その他'
+    return tags
 
 
 def main():
     input_path = 'data/experiments/sarcasm_baseline/misclassified.csv'
-    output_path = 'data/experiments/sarcasm_baseline/misclassified_categorized.csv'
+    output_path = 'data/experiments/sarcasm_baseline/misclassified_tagged.csv'
 
     print('=' * 70)
-    print('誤分類サンプルのヒューリスティック自動分類')
+    print('誤分類サンプルのヒューリスティックタグ付け')
     print('=' * 70)
 
     if not os.path.exists(input_path):
         raise FileNotFoundError(
             f'{input_path} が見つかりません。\n'
-            f'先に make exec CMD="python scripts/experiments/analyze_misclassified.py" を実行してください。'
+            f'先に analyze_misclassified.py を実行してください。'
         )
 
     df = pd.read_csv(input_path)
     print(f'\n[1/3] 入力読み込み: {len(df)}件')
 
-    # カテゴリ付与
-    print('[2/3] カテゴリ判定中...')
-    df['category'] = df['review_text'].apply(classify)
+    # タグ付与
+    print('[2/3] タグ付け中...')
+    df['tags_list'] = df['review_text'].apply(assign_tags)
+    df['tags'] = df['tags_list'].apply(lambda lst: ','.join(lst))
+    df['tag_count'] = df['tags_list'].apply(len)
 
-    # ソート: category順 → 各カテゴリ内confidence降順
-    category_rank = {c: i for i, c in enumerate(CATEGORY_ORDER)}
-    df['_category_rank'] = df['category'].map(category_rank)
-    df = df.sort_values(
-        by=['_category_rank', 'confidence'],
-        ascending=[True, False]
-    ).drop(columns=['_category_rank']).reset_index(drop=True)
+    # confidence降順でソート
+    df = df.sort_values(by='confidence', ascending=False).reset_index(drop=True)
 
-    # 保存
-    df.to_csv(output_path, index=False)
+    # 保存（tags_listは内部用なので除外）
+    save_df = df.drop(columns=['tags_list'])
+    save_df.to_csv(output_path, index=False)
     print(f'[3/3] 出力保存: {output_path}')
 
-    # 集計表示
-    print('\n【カテゴリ別件数（全体）】')
-    counts = df['category'].value_counts()
-    for cat in CATEGORY_ORDER:
-        n = counts.get(cat, 0)
-        pct = n / len(df) * 100 if len(df) else 0
-        print(f'  {cat:10} : {n:>4}件 ({pct:5.1f}%)')
+    # --- 集計1: 各タグの出現件数 ---
+    print('\n【各タグの出現件数（共起含む・重複カウント）】')
+    tag_counter = Counter()
+    for tags in df['tags_list']:
+        tag_counter.update(tags)
 
-    # confidence帯別の集計
-    print('\n【カテゴリ × confidence帯】')
-    print(f'  {"カテゴリ":10} | {"≥0.9":>5} | {"0.7-0.9":>8} | {"<0.7":>5}')
-    print('  ' + '-' * 45)
-    for cat in CATEGORY_ORDER:
-        sub = df[df['category'] == cat]
-        high = (sub['confidence'] >= 0.9).sum()
-        mid = ((sub['confidence'] >= 0.7) & (sub['confidence'] < 0.9)).sum()
-        low = (sub['confidence'] < 0.7).sum()
-        if high + mid + low > 0:
-            print(f'  {cat:10} | {high:>5} | {mid:>8} | {low:>5}')
+    total = len(df)
+    print(f'  {"タグ":12} | {"件数":>5} | {"全体に占める割合":>15}')
+    print('  ' + '-' * 50)
+    for tag in TAG_ORDER:
+        cnt = tag_counter.get(tag, 0)
+        pct = cnt / total * 100
+        print(f'  {tag:12} | {cnt:>5} | {pct:>14.1f}%')
 
-    # FP/FN別の集計
-    print('\n【カテゴリ × FP/FN】')
-    print(f'  {"カテゴリ":10} | {"FP":>5} | {"FN":>5}')
-    print('  ' + '-' * 30)
-    for cat in CATEGORY_ORDER:
-        sub = df[df['category'] == cat]
+    # --- 集計2: タグ数の分布 ---
+    print('\n【1レビューあたりのタグ数分布】')
+    count_dist = df['tag_count'].value_counts().sort_index()
+    for n, cnt in count_dist.items():
+        pct = cnt / total * 100
+        bar = '#' * int(pct / 2)
+        print(f'  {n}個: {cnt:>4}件 ({pct:>5.1f}%) {bar}')
+
+    # --- 集計3: タグなしレビュー数 ---
+    no_tag = (df['tag_count'] == 0).sum()
+    print(f'\n【真の「その他」(タグなし)】: {no_tag}件 ({no_tag / total * 100:.1f}%)')
+
+    # --- 集計4: タグ共起の頻出パターン ---
+    print('\n【タグ共起の頻出パターン Top10（2タグ組み合わせ）】')
+    pair_counter = Counter()
+    for tags in df['tags_list']:
+        if len(tags) >= 2:
+            for pair in combinations(sorted(tags), 2):
+                pair_counter[pair] += 1
+
+    if pair_counter:
+        for (a, b), cnt in pair_counter.most_common(10):
+            pct = cnt / total * 100
+            print(f'  {a} + {b}: {cnt}件 ({pct:.1f}%)')
+    else:
+        print('  （共起なし）')
+
+    # --- 集計5: タグ × FP/FN ---
+    print('\n【タグ × FP/FN】')
+    print(f'  {"タグ":12} | {"FP":>5} | {"FN":>5}')
+    print('  ' + '-' * 32)
+    for tag in TAG_ORDER:
+        sub = df[df['tags_list'].apply(lambda lst: tag in lst)]
         fp = (sub['error_type'] == 'FP').sum()
         fn = (sub['error_type'] == 'FN').sum()
         if fp + fn > 0:
-            print(f'  {cat:10} | {fp:>5} | {fn:>5}')
+            print(f'  {tag:12} | {fp:>5} | {fn:>5}')
 
     print('\n' + '=' * 70)
-    print('分類完了')
+    print('タグ付け完了')
     print('=' * 70)
 
 

--- a/scripts/experiments/categorize_misclassified.py
+++ b/scripts/experiments/categorize_misclassified.py
@@ -1,0 +1,191 @@
+"""
+誤分類サンプルのヒューリスティック自動分類
+
+misclassified.csvの各レビューにルールベースでカテゴリを付与する。
+モデルの弱点パターン（皮肉・否定・混合感情など）を傾向把握するための一次分類。
+
+入力:
+    data/experiments/sarcasm_baseline/misclassified.csv
+
+出力:
+    data/experiments/sarcasm_baseline/misclassified_categorized.csv
+    （category列追加・category順 + 各カテゴリ内confidence降順でソート）
+"""
+
+import os
+import re
+
+import pandas as pd
+
+
+NEGATION_WORDS = [
+    'not', 'never', 'no', "don't", "doesn't", "didn't",
+    "can't", "couldn't", "isn't", "wasn't", "aren't", "weren't",
+    "won't", "wouldn't", 'nothing', 'nobody', 'nowhere',
+]
+
+NEGATIVE_WORDS = [
+    'bad', 'awful', 'terrible', 'horrible', 'boring', 'broken',
+    'disappointed', 'disappointing', 'wrong', 'useless', 'impossible',
+    'worst', 'poor', 'weak', 'dull',
+]
+
+MIXED_WORDS = ['but', 'however', 'although', 'though', 'despite']
+
+RATING_PATTERNS = [
+    r'\b0/10\b', r'\b10/10\b', r'★', r'\b100%\b',
+    r'\b1/10\b', r'\b9/10\b',
+]
+
+SLANG_WORDS = ['fr', 'no cap', 'slaps', 'mid', 'ngl', 'based', 'cringe']
+
+# カテゴリ判定の優先順位
+CATEGORY_ORDER = [
+    '二重否定', '単純否定', '混合感情', '評価記号矛盾',
+    'スラング', '全大文字強調', '短文', 'その他',
+]
+
+
+def _contains_word(text_lower: str, words: list[str]) -> bool:
+    """単語の境界を考慮した部分一致判定"""
+    for w in words:
+        # 単語境界で囲んで検索（アポストロフィを含む場合は別処理）
+        pattern = r'\b' + re.escape(w) + r'\b'
+        if re.search(pattern, text_lower):
+            return True
+    return False
+
+
+def _has_double_negation(text_lower: str) -> bool:
+    """否定語の近くにネガティブ語があるか（5単語以内）"""
+    tokens = re.findall(r"[a-z']+", text_lower)
+    negation_indices = [i for i, t in enumerate(tokens) if t in NEGATION_WORDS]
+    negative_set = set(NEGATIVE_WORDS)
+
+    for idx in negation_indices:
+        # 否定語の直後5単語以内にネガティブ語があるか
+        for j in range(idx + 1, min(idx + 6, len(tokens))):
+            if tokens[j] in negative_set:
+                return True
+    return False
+
+
+def _is_all_caps(text: str, threshold: float = 0.5) -> bool:
+    """テキストの大文字率が閾値以上か（アルファベットに対する割合）"""
+    letters = [c for c in text if c.isalpha()]
+    if len(letters) < 10:  # 短すぎる場合は判定しない
+        return False
+    upper_count = sum(1 for c in letters if c.isupper())
+    return upper_count / len(letters) >= threshold
+
+
+def classify(text: str) -> str:
+    """1レビューにカテゴリを付与"""
+    if not isinstance(text, str) or not text:
+        return 'その他'
+
+    text_lower = text.lower()
+
+    # 1. 二重否定（最優先 - 二重否定は意味が反転して肯定になる）
+    if _has_double_negation(text_lower):
+        return '二重否定'
+
+    # 2. 単純否定
+    if _contains_word(text_lower, NEGATION_WORDS):
+        return '単純否定'
+
+    # 3. 混合感情
+    if _contains_word(text_lower, MIXED_WORDS):
+        return '混合感情'
+
+    # 4. 評価記号矛盾
+    for pattern in RATING_PATTERNS:
+        if re.search(pattern, text):
+            return '評価記号矛盾'
+
+    # 5. スラング
+    if _contains_word(text_lower, SLANG_WORDS):
+        return 'スラング'
+
+    # 6. 全大文字強調
+    if _is_all_caps(text):
+        return '全大文字強調'
+
+    # 7. 短文
+    if len(text) < 50:
+        return '短文'
+
+    return 'その他'
+
+
+def main():
+    input_path = 'data/experiments/sarcasm_baseline/misclassified.csv'
+    output_path = 'data/experiments/sarcasm_baseline/misclassified_categorized.csv'
+
+    print('=' * 70)
+    print('誤分類サンプルのヒューリスティック自動分類')
+    print('=' * 70)
+
+    if not os.path.exists(input_path):
+        raise FileNotFoundError(
+            f'{input_path} が見つかりません。\n'
+            f'先に make exec CMD="python scripts/experiments/analyze_misclassified.py" を実行してください。'
+        )
+
+    df = pd.read_csv(input_path)
+    print(f'\n[1/3] 入力読み込み: {len(df)}件')
+
+    # カテゴリ付与
+    print('[2/3] カテゴリ判定中...')
+    df['category'] = df['review_text'].apply(classify)
+
+    # ソート: category順 → 各カテゴリ内confidence降順
+    category_rank = {c: i for i, c in enumerate(CATEGORY_ORDER)}
+    df['_category_rank'] = df['category'].map(category_rank)
+    df = df.sort_values(
+        by=['_category_rank', 'confidence'],
+        ascending=[True, False]
+    ).drop(columns=['_category_rank']).reset_index(drop=True)
+
+    # 保存
+    df.to_csv(output_path, index=False)
+    print(f'[3/3] 出力保存: {output_path}')
+
+    # 集計表示
+    print('\n【カテゴリ別件数（全体）】')
+    counts = df['category'].value_counts()
+    for cat in CATEGORY_ORDER:
+        n = counts.get(cat, 0)
+        pct = n / len(df) * 100 if len(df) else 0
+        print(f'  {cat:10} : {n:>4}件 ({pct:5.1f}%)')
+
+    # confidence帯別の集計
+    print('\n【カテゴリ × confidence帯】')
+    print(f'  {"カテゴリ":10} | {"≥0.9":>5} | {"0.7-0.9":>8} | {"<0.7":>5}')
+    print('  ' + '-' * 45)
+    for cat in CATEGORY_ORDER:
+        sub = df[df['category'] == cat]
+        high = (sub['confidence'] >= 0.9).sum()
+        mid = ((sub['confidence'] >= 0.7) & (sub['confidence'] < 0.9)).sum()
+        low = (sub['confidence'] < 0.7).sum()
+        if high + mid + low > 0:
+            print(f'  {cat:10} | {high:>5} | {mid:>8} | {low:>5}')
+
+    # FP/FN別の集計
+    print('\n【カテゴリ × FP/FN】')
+    print(f'  {"カテゴリ":10} | {"FP":>5} | {"FN":>5}')
+    print('  ' + '-' * 30)
+    for cat in CATEGORY_ORDER:
+        sub = df[df['category'] == cat]
+        fp = (sub['error_type'] == 'FP').sum()
+        fn = (sub['error_type'] == 'FN').sum()
+        if fp + fn > 0:
+            print(f'  {cat:10} | {fp:>5} | {fn:>5}')
+
+    print('\n' + '=' * 70)
+    print('分類完了')
+    print('=' * 70)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/experiments/explain_misclassified.py
+++ b/scripts/experiments/explain_misclassified.py
@@ -1,0 +1,342 @@
+"""
+誤分類サンプルのモデル解釈性分析
+
+transformers-interpret（Layer Integrated Gradients）を使い、
+誤分類577件の各レビューに対してトークンごとの寄与度を算出する。
+
+入力:
+    data/experiments/sarcasm_baseline/misclassified.csv
+    models/best_model/
+
+出力:
+    data/experiments/sarcasm_baseline/explanations/
+    ├── token_scores.csv    詳細：review_id × token × score
+    ├── top_words.csv       集計：各レビューの上位5トークン
+    └── summary.json        モデル全体の傾向：誤判定を引き起こす単語TOP
+"""
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
+
+import pandas as pd
+import torch
+import torch.nn as nn
+from tqdm import tqdm
+from transformers.modeling_outputs import SequenceClassifierOutput
+from transformers_interpret import SequenceClassificationExplainer
+
+from src.nlp.model import load_model
+
+
+class HuggingFaceCompatibleWrapper(nn.Module):
+    """
+    SentimentClassifierをHuggingFace互換にラップ
+
+    transformers-interpretが内部で参照する属性をすべて満たす:
+    - model.config（model_type, id2label, label2id）
+    - model.base_model_prefix（base model属性名）
+    - model.distilbert（base_model_prefixが指すDistilBERT本体）
+    - model.get_input_embeddings()
+    - forward() が SequenceClassifierOutput を返す
+    """
+
+    base_model_prefix = "distilbert"
+
+    def __init__(self, sentiment_classifier: nn.Module):
+        super().__init__()
+        self.inner = sentiment_classifier
+        # base_model_prefix が指す属性を露出（getattr(model, 'distilbert')で取れるように）
+        self.distilbert = self.inner.bert
+        # configを設定
+        self.config = self.inner.bert.config
+        self.config.id2label = {0: 'NEGATIVE', 1: 'POSITIVE'}
+        self.config.label2id = {'NEGATIVE': 0, 'POSITIVE': 1}
+
+    def forward(self, input_ids=None, attention_mask=None, **kwargs):
+        logits = self.inner(input_ids=input_ids, attention_mask=attention_mask)
+        return SequenceClassifierOutput(logits=logits)
+
+    def get_input_embeddings(self):
+        """transformers-interpretが内部で呼ぶ"""
+        return self.distilbert.get_input_embeddings()
+
+    @property
+    def device(self):
+        """HuggingFaceモデルが持つdeviceプロパティを再現"""
+        return next(self.parameters()).device
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='誤分類サンプルの解釈性分析')
+    parser.add_argument('--limit', type=int, default=None,
+                        help='処理件数の上限（デフォルト全件）')
+    parser.add_argument('--confidence-min', type=float, default=None,
+                        help='confidence最小値でフィルタ（例: 0.9で高信頼度誤分類のみ）')
+    parser.add_argument('--checkpoint-interval', type=int, default=50,
+                        help='何件処理ごとに途中保存するか')
+    parser.add_argument('--resume', action='store_true',
+                        help='既存のtoken_scores.csvを読み込み、未処理分のみ続行')
+    return parser.parse_args()
+
+
+def aggregate_top_words(
+    token_scores_df: pd.DataFrame,
+    misclassified_df: pd.DataFrame,
+    top_n: int = 5
+) -> pd.DataFrame:
+    """
+    各レビューの寄与度TOP N単語を抽出（P方向・N方向の両方）
+
+    出力カラム:
+        review_id, review_text, actual, predicted, confidence, error_type,
+        pos1_token, pos1_score, ..., pos5_token, pos5_score,
+        neg1_token, neg1_score, ..., neg5_token, neg5_score
+    """
+    # 特殊トークン（[CLS]/[SEP]等）を除外
+    df = token_scores_df[~token_scores_df['token'].str.startswith('[')].copy()
+
+    rows = []
+    for review_id, grp in df.groupby('review_id'):
+        row = {'review_id': review_id}
+
+        # P方向（正の寄与）TOP N
+        pos_tokens = grp[grp['score'] > 0].nlargest(top_n, 'score')
+        for i, (_, t) in enumerate(pos_tokens.iterrows(), start=1):
+            row[f'pos{i}_token'] = t['token']
+            row[f'pos{i}_score'] = round(t['score'], 4)
+        # 足りない場合は空欄で埋める
+        for i in range(len(pos_tokens) + 1, top_n + 1):
+            row[f'pos{i}_token'] = ''
+            row[f'pos{i}_score'] = ''
+
+        # N方向（負の寄与）TOP N
+        neg_tokens = grp[grp['score'] < 0].nsmallest(top_n, 'score')
+        for i, (_, t) in enumerate(neg_tokens.iterrows(), start=1):
+            row[f'neg{i}_token'] = t['token']
+            row[f'neg{i}_score'] = round(t['score'], 4)
+        for i in range(len(neg_tokens) + 1, top_n + 1):
+            row[f'neg{i}_token'] = ''
+            row[f'neg{i}_score'] = ''
+
+        rows.append(row)
+
+    top_df = pd.DataFrame(rows)
+
+    # misclassified情報を結合
+    meta_cols = ['review_id', 'review_text', 'actual',
+                 'predicted', 'confidence', 'error_type']
+    merged = misclassified_df[meta_cols].merge(top_df, on='review_id', how='inner')
+
+    # カラム順を整理: メタ情報 → P方向 → N方向
+    pos_cols = [f'pos{i}_{x}' for i in range(1, top_n + 1) for x in ['token', 'score']]
+    neg_cols = [f'neg{i}_{x}' for i in range(1, top_n + 1) for x in ['token', 'score']]
+    result = merged[meta_cols + pos_cols + neg_cols]
+
+    # confidence降順でソート（高信頼度誤分類が上に来る）
+    return result.sort_values('confidence', ascending=False).reset_index(drop=True)
+
+
+def build_summary(token_scores_df: pd.DataFrame, misclassified_df: pd.DataFrame) -> dict:
+    """モデル全体の傾向サマリーを作成"""
+    # error_type を結合
+    df = token_scores_df.merge(
+        misclassified_df[['review_id', 'error_type']],
+        on='review_id', how='left'
+    )
+
+    # 特殊トークン除外（[CLS], [SEP], [PAD]等）
+    df = df[~df['token'].str.startswith('[')]
+
+    summary = {
+        'total_reviews_analyzed': int(token_scores_df['review_id'].nunique()),
+        'total_tokens': int(len(token_scores_df)),
+    }
+
+    # FP（NをPと誤認）でポジ方向に寄与した単語TOP20
+    fp_pos = df[(df['error_type'] == 'FP') & (df['score'] > 0)]
+    fp_top = (fp_pos.groupby('token')['score'].agg(['sum', 'count'])
+              .sort_values('sum', ascending=False).head(20))
+    summary['fp_top_positive_contributors'] = [
+        {'token': str(idx), 'total_score': round(r['sum'], 4), 'occurrences': int(r['count'])}
+        for idx, r in fp_top.iterrows()
+    ]
+
+    # FN（PをNと誤認）でネガ方向に寄与した単語TOP20
+    fn_neg = df[(df['error_type'] == 'FN') & (df['score'] < 0)]
+    fn_top = (fn_neg.groupby('token')['score'].agg(['sum', 'count'])
+              .sort_values('sum', ascending=True).head(20))
+    summary['fn_top_negative_contributors'] = [
+        {'token': str(idx), 'total_score': round(r['sum'], 4), 'occurrences': int(r['count'])}
+        for idx, r in fn_top.iterrows()
+    ]
+
+    return summary
+
+
+def main():
+    args = parse_args()
+
+    input_path = 'data/experiments/sarcasm_baseline/misclassified.csv'
+    model_dir = 'models/best_model'
+    output_dir = 'data/experiments/sarcasm_baseline/explanations'
+    token_scores_path = os.path.join(output_dir, 'token_scores.csv')
+    top_words_path = os.path.join(output_dir, 'top_words.csv')
+    summary_path = os.path.join(output_dir, 'summary.json')
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    print('=' * 70)
+    print('誤分類サンプルのモデル解釈性分析（Layer Integrated Gradients）')
+    print('=' * 70)
+
+    # 1. データ読み込み
+    df = pd.read_csv(input_path).reset_index(drop=True)
+    df['review_id'] = df.index
+
+    # フィルタ適用
+    if args.confidence_min is not None:
+        df = df[df['confidence'] >= args.confidence_min].copy()
+    if args.limit is not None:
+        df = df.head(args.limit).copy()
+
+    print(f'\n[1/4] 入力読み込み: {len(df)}件')
+
+    # 既存処理分（resume対応）
+    done_ids = set()
+    if args.resume and os.path.exists(token_scores_path):
+        existing = pd.read_csv(token_scores_path)
+        done_ids = set(existing['review_id'].unique())
+        print(f'   既存処理済み: {len(done_ids)}件 (--resume指定)')
+    elif not args.resume and os.path.exists(token_scores_path):
+        # --resume指定なしで既存ファイルがある場合は削除（重複追加防止）
+        os.remove(token_scores_path)
+        print(f'   既存のtoken_scores.csvを削除（--resume未指定のため）')
+
+    # 2. モデル読み込み
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    print(f'\n[2/4] モデル読み込み (device={device})')
+    model, tokenizer = load_model(model_dir, device=device)
+    model.eval()
+
+    # transformers-interpretはHuggingFace互換のmodel.configを期待するためラップ
+    wrapped_model = HuggingFaceCompatibleWrapper(model).to(device)
+    wrapped_model.eval()
+
+    explainer = SequenceClassificationExplainer(
+        model=wrapped_model,
+        tokenizer=tokenizer,
+    )
+
+    # 3. 解釈性分析
+    print(f'\n[3/4] 解釈性分析 (Layer Integrated Gradients)')
+
+    target_class_idx = {0: 0, 1: 1}  # 0=Negative, 1=Positive
+    rows_buffer = []
+    processed_count = 0
+
+    # 新規ファイルなら最初にヘッダー出力、--resumeで既存に追記する場合はヘッダーなし
+    write_header = not os.path.exists(token_scores_path)
+
+    for _, row in tqdm(df.iterrows(), total=len(df), desc='Explaining'):
+        review_id = int(row['review_id'])
+        if review_id in done_ids:
+            continue
+
+        text = str(row['review_text'])
+        # モデルが予測したクラスに対する寄与度を計算
+        predicted_class = 1 if row['predicted'] == 'P' else 0
+
+        try:
+            attributions = explainer(
+                text=text,
+                class_name=str(predicted_class),
+            )
+        except Exception as e:
+            print(f'   ⚠ review_id={review_id} スキップ: {e}')
+            continue
+
+        for token, score in attributions:
+            rows_buffer.append({
+                'review_id': review_id,
+                'token': token,
+                'score': float(score),
+            })
+
+        processed_count += 1
+
+        # チェックポイント保存
+        if processed_count % args.checkpoint_interval == 0:
+            tmp_df = pd.DataFrame(rows_buffer)
+            tmp_df.to_csv(token_scores_path, mode='a',
+                          header=write_header, index=False)
+            write_header = False
+            rows_buffer.clear()
+
+    # 残り分を保存
+    if rows_buffer:
+        tmp_df = pd.DataFrame(rows_buffer)
+        tmp_df.to_csv(token_scores_path, mode='a',
+                      header=write_header, index=False)
+
+    print(f'\n   ✓ token_scores.csv 保存: {token_scores_path}')
+
+    # 4. 集計・サマリー作成
+    print(f'\n[4/4] 集計・サマリー作成')
+    token_scores_df = pd.read_csv(token_scores_path)
+
+    # misclassified情報の再読み込み（review_text等を結合用に使う）
+    misclassified_df = pd.read_csv(input_path).reset_index(drop=True)
+    misclassified_df['review_id'] = misclassified_df.index
+
+    # 上位5単語（P方向・N方向それぞれ + メタ情報付き）
+    top_words_df = aggregate_top_words(token_scores_df, misclassified_df, top_n=5)
+    # 出力からreview_id削除（confidence順なので不要）
+    top_words_df = top_words_df.drop(columns=['review_id'])
+    top_words_df.to_csv(top_words_path, index=False)
+    print(f'   ✓ top_words.csv 保存: {top_words_path}')
+
+    # token_scores.csv を最終整形（review_text/confidence/error_type追加・ソート・review_id削除）
+    enriched = token_scores_df.merge(
+        misclassified_df[['review_id', 'review_text', 'confidence', 'error_type']],
+        on='review_id', how='left'
+    )
+    enriched = enriched.sort_values(
+        ['confidence', 'score'], ascending=[False, False]
+    ).reset_index(drop=True)
+    final_token_scores = enriched[
+        ['review_text', 'confidence', 'error_type', 'token', 'score']
+    ]
+    final_token_scores.to_csv(token_scores_path, index=False)
+    print(f'   ✓ token_scores.csv 最終整形: {token_scores_path}')
+
+    # サマリー
+    summary = build_summary(token_scores_df, misclassified_df)
+
+    with open(summary_path, 'w', encoding='utf-8') as f:
+        json.dump(summary, f, ensure_ascii=False, indent=2)
+    print(f'   ✓ summary.json 保存: {summary_path}')
+
+    # コンソール表示
+    print(f'\n【サマリー】')
+    print(f'  分析件数: {summary["total_reviews_analyzed"]}件')
+    print(f'  総トークン数: {summary["total_tokens"]}件')
+
+    print(f'\n【FP（NをPと誤認）でポジ方向に寄与した単語 TOP10】')
+    for item in summary['fp_top_positive_contributors'][:10]:
+        print(f"  {item['token']:20} | sum={item['total_score']:>7.3f} | 出現={item['occurrences']}回")
+
+    print(f'\n【FN（PをNと誤認）でネガ方向に寄与した単語 TOP10】')
+    for item in summary['fn_top_negative_contributors'][:10]:
+        print(f"  {item['token']:20} | sum={item['total_score']:>7.3f} | 出現={item['occurrences']}回")
+
+    print('\n' + '=' * 70)
+    print('解釈性分析完了')
+    print('=' * 70)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/experiments/explain_misclassified.py
+++ b/scripts/experiments/explain_misclassified.py
@@ -140,39 +140,113 @@ def aggregate_top_words(
     return result.sort_values('confidence', ascending=False).reset_index(drop=True)
 
 
-def build_summary(token_scores_df: pd.DataFrame, misclassified_df: pd.DataFrame) -> dict:
-    """モデル全体の傾向サマリーを作成"""
+# 英語ストップワード（頻出だが意味希薄なため集計から除外）
+STOPWORDS = {
+    'i', 'a', 'an', 'the', 'and', 'or', 'but', 'if', 'so', 'to', 'of', 'in', 'on',
+    'at', 'for', 'with', 'as', 'by', 'is', 'are', 'was', 'were', 'be', 'been',
+    'being', 'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'should',
+    'could', 'can', 'may', 'might', 'must', 'this', 'that', 'these', 'those',
+    'my', 'your', 'his', 'her', 'its', 'our', 'their', 'me', 'you', 'him', 'us',
+    'them', 'we', 'he', 'she', 'it', 'they', 'what', 'which', 'who', 'when',
+    'where', 'why', 'how', 'all', 'each', 'every', 'some', 'any', 'no', 'not',
+    'only', 'own', 'same', 'than', 'then', 'too', 'very', 'just', 'one', 'two',
+    'there', 'here', 'where',
+}
+
+# 短縮形の断片（don't, you've, it's等がtokenizerで分割された残り）
+CONTRACTION_FRAGMENTS = {
+    # アポストロフィの後ろ部分
+    's', 't', 'd', 'm', 'll', 've', 're',
+    # アポストロフィの前部分（"...n't"系）
+    'don', 'won', 'isn', 'wasn', 'aren', 'weren',
+    'doesn', 'didn', 'couldn', 'wouldn', 'shouldn',
+    'hasn', 'haven', 'hadn', 'mustn', 'mightn', 'needn',
+    'ain', 'shan',
+}
+
+# 集計対象とする最小トークン長（短い断片を除外）
+MIN_TOKEN_LENGTH = 3
+
+
+def _is_meaningful_token(token: str) -> bool:
+    """集計対象として意味のあるトークンか判定"""
+    if not isinstance(token, str):
+        return False
+    # 特殊トークン除外
+    if token.startswith('['):
+        return False
+    # サブワード断片除外（##で始まる）
+    if token.startswith('##'):
+        return False
+    # 記号のみ除外
+    if not any(c.isalpha() for c in token):
+        return False
+    # 最小長フィルタ（s, t, ve, ll, re, m, d等の断片除外）
+    if len(token) < MIN_TOKEN_LENGTH:
+        return False
+    # ストップワード除外
+    if token.lower() in STOPWORDS:
+        return False
+    # 短縮形断片除外
+    if token.lower() in CONTRACTION_FRAGMENTS:
+        return False
+    return True
+
+
+def build_summary(
+    token_scores_df: pd.DataFrame,
+    misclassified_df: pd.DataFrame,
+    min_occurrences: int = 5,
+    top_n: int = 20,
+) -> dict:
+    """モデル全体の傾向サマリーを作成
+
+    Args:
+        min_occurrences: 集計に含める最小出現回数（ノイズ除去）
+        top_n: 各カテゴリで上位何件を返すか
+    """
     # error_type を結合
     df = token_scores_df.merge(
         misclassified_df[['review_id', 'error_type']],
         on='review_id', how='left'
     )
 
-    # 特殊トークン除外（[CLS], [SEP], [PAD]等）
-    df = df[~df['token'].str.startswith('[')]
+    # 意味のあるトークンのみに絞る（特殊トークン・記号・サブワード・ストップワード除外）
+    df = df[df['token'].apply(_is_meaningful_token)]
 
     summary = {
         'total_reviews_analyzed': int(token_scores_df['review_id'].nunique()),
-        'total_tokens': int(len(token_scores_df)),
+        'total_tokens_after_filter': int(len(df)),
+        'filter_criteria': {
+            'min_occurrences': min_occurrences,
+            'stopwords_excluded': True,
+            'subwords_excluded': True,
+            'special_tokens_excluded': True,
+        }
     }
 
-    # FP（NをPと誤認）でポジ方向に寄与した単語TOP20
-    fp_pos = df[(df['error_type'] == 'FP') & (df['score'] > 0)]
-    fp_top = (fp_pos.groupby('token')['score'].agg(['sum', 'count'])
-              .sort_values('sum', ascending=False).head(20))
-    summary['fp_top_positive_contributors'] = [
-        {'token': str(idx), 'total_score': round(r['sum'], 4), 'occurrences': int(r['count'])}
-        for idx, r in fp_top.iterrows()
-    ]
+    def _aggregate(sub_df: pd.DataFrame, ascending: bool) -> list:
+        """token単位で集計し、mean_score基準で並べる（最小出現回数フィルタ付き）"""
+        agg = sub_df.groupby('token')['score'].agg(['sum', 'mean', 'count'])
+        agg = agg[agg['count'] >= min_occurrences]
+        agg = agg.sort_values('mean', ascending=ascending).head(top_n)
+        return [
+            {
+                'token': str(idx),
+                'mean_score': round(r['mean'], 4),
+                'total_score': round(r['sum'], 4),
+                'occurrences': int(r['count']),
+            }
+            for idx, r in agg.iterrows()
+        ]
 
-    # FN（PをNと誤認）でネガ方向に寄与した単語TOP20
+    # FP（NをPと誤認）でポジ方向に寄与した単語
+    fp_pos = df[(df['error_type'] == 'FP') & (df['score'] > 0)]
+    summary['fp_top_positive_contributors'] = _aggregate(fp_pos, ascending=False)
+
+    # FN（PをNと誤認）でネガ方向に寄与した単語
     fn_neg = df[(df['error_type'] == 'FN') & (df['score'] < 0)]
-    fn_top = (fn_neg.groupby('token')['score'].agg(['sum', 'count'])
-              .sort_values('sum', ascending=True).head(20))
-    summary['fn_top_negative_contributors'] = [
-        {'token': str(idx), 'total_score': round(r['sum'], 4), 'occurrences': int(r['count'])}
-        for idx, r in fn_top.iterrows()
-    ]
+    summary['fn_top_negative_contributors'] = _aggregate(fn_neg, ascending=True)
 
     return summary
 
@@ -323,15 +397,19 @@ def main():
     # コンソール表示
     print(f'\n【サマリー】')
     print(f'  分析件数: {summary["total_reviews_analyzed"]}件')
-    print(f'  総トークン数: {summary["total_tokens"]}件')
+    print(f'  フィルタ後トークン数: {summary["total_tokens_after_filter"]}件')
+    print(f'  フィルタ条件: 最小出現{summary["filter_criteria"]["min_occurrences"]}回, '
+          f'ストップワード/サブワード/特殊トークン除外')
 
-    print(f'\n【FP（NをPと誤認）でポジ方向に寄与した単語 TOP10】')
+    print(f'\n【FP（NをPと誤認）でポジ方向に寄与した単語 TOP10（mean_score順）】')
     for item in summary['fp_top_positive_contributors'][:10]:
-        print(f"  {item['token']:20} | sum={item['total_score']:>7.3f} | 出現={item['occurrences']}回")
+        print(f"  {item['token']:15} | mean={item['mean_score']:>6.3f} | "
+              f"sum={item['total_score']:>7.3f} | 出現={item['occurrences']}回")
 
-    print(f'\n【FN（PをNと誤認）でネガ方向に寄与した単語 TOP10】')
+    print(f'\n【FN（PをNと誤認）でネガ方向に寄与した単語 TOP10（mean_score順）】')
     for item in summary['fn_top_negative_contributors'][:10]:
-        print(f"  {item['token']:20} | sum={item['total_score']:>7.3f} | 出現={item['occurrences']}回")
+        print(f"  {item['token']:15} | mean={item['mean_score']:>6.3f} | "
+              f"sum={item['total_score']:>7.3f} | 出現={item['occurrences']}回")
 
     print('\n' + '=' * 70)
     print('解釈性分析完了')


### PR DESCRIPTION
## Summary

Issue #19 のStep B「実データの誤分類抽出」を完了。現状モデル（Test Acc 84.66%）の弱点を3層の分析で定量化した。

このPRは即マージせず、**プロジェクト全体の方向性を検討してから判断**する想定。

## 実装内容

### 1. 誤分類分析スクリプト（baseline取得）
\`scripts/experiments/analyze_misclassified.py\`
- \`models/best_model\` で \`reviews_10000.csv\` 全件予測
- 誤分類サンプルを抽出し \`misclassified.csv\` に保存
- 全モデルの集計を \`summary.csv\` に追記型で記録

### 2. ヒューリスティックタグ付け（マルチラベル）
\`scripts/experiments/categorize_misclassified.py\`
- 1レビューに複数タグを付与（否定/混合/強ネガ/評価記号/スラング/大文字/短文/長文）
- タグ共起の頻出パターン集計
- 真の「その他」（タグなし）を121件まで絞り込み

### 3. モデル解釈性分析（Layer Integrated Gradients）
\`scripts/experiments/explain_misclassified.py\`
- \`transformers-interpret\` で各レビューの単語寄与度を算出
- SentimentClassifierをHuggingFace互換にラップ
- P方向/N方向TOP5を分離出力、confidence降順ソート

## 主な発見

### 全体統計
- 全体精度 94.15%（訓練データ含む楽観値）
- 誤分類577件中、高信頼度誤分類（≥0.9）が205件（35.5%）
- FP（NをPと誤認）が高信頼度に偏り、FN（PをNと誤認）は低信頼度に偏る

### モデルの弱点パターン
- 「否定 + 逆接」共起が最頻出（75件・13.0%）
- 長文ではFPが顕著（FP:FN = 約2:1）
- 高信頼度の単語寄与度では「good」「but」が誤判定の主因

### 本質的限界の発見
人間目視で121件の「真のその他」を確認した結果、以下が判明：
- ラベル誤り（投稿者の操作ミス含む）が一定数存在
- 皮肉・反語など人間でも判断が分かれるケースが多い
- Steam レビュー特有のジョーク・中毒表現（"consumed my life"等）

→ **モデル改善より「データの本質的ノイズ」が支配的**との結論。
   現状の84.66%は実用上問題なし、次フェーズ（時系列）に進むのが現実的。

## 関連
- Issue #19 に詳細な分析結果を追記済み
- Wiki: [モデルの解釈性](https://github.com/rindguitar/game-demand-forecast/wiki/Model-Interpretability), [ヒューリスティック自動分類](https://github.com/rindguitar/game-demand-forecast/wiki/Heuristic-Classification)

## Test plan
- [x] \`make exec CMD="python scripts/experiments/analyze_misclassified.py"\` 577件正常実行
- [x] \`make exec CMD="python scripts/experiments/categorize_misclassified.py"\` タグ付け正常完了
- [x] \`make exec CMD="python scripts/experiments/explain_misclassified.py"\` 解釈性分析正常完了
- [x] 各出力CSV/JSONの内容確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)