### PR TITLE
feat: OOD性能比較ベンチマーク（自作モデル vs sst-2）

### DIFF
--- a/scripts/collect/collect_ood_testset.py
+++ b/scripts/collect/collect_ood_testset.py
@@ -11,9 +11,13 @@ OODテストセット収集スクリプト
 - 目標: 20ゲーム × (Positive 50 + Negative 50) = 2000件（balanced）
 
 ジャンル偏り対策（特定ジャンルがテストセットを占有しないように）:
-- ノイズタグ（Indie / Free To Play）は判定から除外（遊びの種類を表さないため）
-- (a) 除去後のジャンル集合が採用済みと完全一致なら弾く（同一プロファイルの重複防止）
+- ノイズタグ（Indie / Free To Play / Early Access）は判定から除外（遊びの種類を表さないため）
+- (a) 除去後のジャンル集合が同一なら --max-per-profile 本までに制限（同一プロファイルの重複防止）
 - (b) 1ジャンルあたりの所属数に上限（--max-per-genre）を設ける（メインジャンルの偏り防止）
+
+似たゲーム除外（粗いgenresが取りこぼす細かい被りをユーザータグで検出）:
+- (C-2) storeページのユーザータグ上位N個を取得し、ノイズタグ(TAG_NOISE)を除去後、
+  採用済みゲームと閾値以上タグが共通する「似たゲーム」を弾く（例: Puzzle系・Roguelike系の重複）
 
 再利用可能な汎用ツールとして設計（他プロジェクトでも流用可）。
 """
@@ -21,6 +25,7 @@ OODテストセット収集スクリプト
 import os
 import sys
 import re
+import html
 import time
 import random
 import argparse
@@ -46,6 +51,14 @@ TRAIN_GAME_IDS = {
 # ジャンル判定から除外するノイズタグ
 # 遊びの種類ではなく、開発規模(Indie)・価格モデル(Free To Play)・販売ステータス(Early Access)を表すため
 NOISE_TAGS = {'Indie', 'Free To Play', 'Early Access'}
+
+# タグ重なり判定から除外するノイズタグ
+# 17本の実データ分析で「無関係なゲーム同士の誤爆」を生んでいたタグを特定（憶測ではなく実例ベース）。
+# 気分・機能・開発規模を表すもので、遊びの被りを意味しないため除外する。
+TAG_NOISE = {
+    'Singleplayer', 'Great Soundtrack', 'Atmospheric', 'Surreal',
+    'Free to Play', 'Indie', 'Early Access',
+}
 
 # Steam APIアクセス時のブラウザUA（データセンターIPからのブロック回避）
 HEADERS = {
@@ -131,15 +144,45 @@ def get_game_genres(app_id: int) -> frozenset:
     return frozenset(g['description'] for g in genres)
 
 
+def get_game_tags(app_id: int, n_tags: int = 6) -> list:
+    """
+    Steam storeページからユーザータグ（上位n_tags個）を取得
+
+    Steam公式の `genres` は粗く「Puzzle」「Roguelike」等の実ジャンルを取りこぼすため、
+    より粒度の細かいユーザータグを使って「似たゲーム」を検出する。タグはstoreページの
+    HTMLに埋め込まれているのでスクレイプする（appdetails APIには含まれない）。
+
+    Args:
+        app_id: SteamのアプリID
+        n_tags: 取得する上位タグ数
+
+    Returns:
+        上位n_tags個のタグ名リスト（取得失敗時は空リスト）
+    """
+    url = f"https://store.steampowered.com/app/{app_id}/"
+    headers = dict(HEADERS)
+    headers['Cookie'] = 'birthtime=0; mature_content=1'  # 年齢確認ゲートを回避
+    response = request_with_backoff(url, headers=headers, timeout=30)
+
+    # <a class="app_tag" ...>\n\tタグ名\t</a> からタグ名を抽出
+    raw = re.findall(r'class="app_tag"[^>]*>\s*([^<]+?)\s*</a>', response.text)
+    tags = [html.unescape(t).strip() for t in raw if t.strip()]
+    return tags[:n_tags]
+
+
 def main():
     parser = argparse.ArgumentParser(description='OODテストセット収集')
     parser.add_argument('--n-games', type=int, default=20, help='採用するゲーム数')
     parser.add_argument('--n-positive', type=int, default=50, help='1ゲームあたりPositive件数')
     parser.add_argument('--n-negative', type=int, default=50, help='1ゲームあたりNegative件数')
-    parser.add_argument('--max-per-genre', type=int, default=4,
+    parser.add_argument('--max-per-genre', type=int, default=6,
                         help='1ジャンルあたりの最大採用数（ジャンル偏り防止）')
     parser.add_argument('--max-per-profile', type=int, default=2,
                         help='同じジャンル集合（プロファイル）あたりの最大採用数')
+    parser.add_argument('--n-tags', type=int, default=6,
+                        help='タグ重なり判定で見る上位タグ数')
+    parser.add_argument('--tag-overlap-threshold', type=int, default=2,
+                        help='採用済みゲームとこの数以上タグが共通したら「似たゲーム」として弾く')
     parser.add_argument('--seed', type=int, default=42, help='ランダムシード')
     parser.add_argument('--output', type=str, default='data/test/reviews_ood_2000.csv',
                         help='出力先CSVパス')
@@ -165,10 +208,11 @@ def main():
     random.shuffle(candidates)
 
     # 2. 各ゲームから条件付き収集
-    print(f"\n[2/3] 条件付き収集（ジャンル偏り対策＋P/N両方が目標数取れたゲームのみ採用）...")
+    print(f"\n[2/3] 条件付き収集（ジャンル偏り対策＋タグ重なり除外＋P/N両方が目標数取れたゲームのみ採用）...")
     print(f"   ジャンル上限: 1ジャンルあたり最大{args.max_per_genre}本 / "
           f"同一プロファイル最大{args.max_per_profile}本")
-    collected_games = []      # (app_id, name, sorted_genres) のリスト
+    print(f"   タグ重なり: 上位{args.n_tags}タグ中{args.tag_overlap_threshold}個以上共通で弾く")
+    collected_games = []      # (app_id, name, sorted_genres, real_tags) のリスト
     all_reviews = []
     genre_counts = {}         # ジャンル名 -> 採用済み本数
     profile_counts = {}       # ジャンル集合(frozenset) -> 採用済み本数（完全一致dedup用）
@@ -203,6 +247,26 @@ def main():
             print(f"    ⚠️ ジャンル上限 {over} に到達 → スキップ")
             continue
 
+        # (C-2) タグ重なり除外: 採用済みゲームとタグが多数共通する「似たゲーム」を弾く
+        # （genresは粗くPuzzle/Roguelike等の実ジャンルを取りこぼすため、細かいタグで判定）
+        try:
+            tags = get_game_tags(app_id, n_tags=args.n_tags)
+        except Exception as e:
+            print(f"    ❌ タグ取得エラー: {e} → スキップ")
+            continue
+        time.sleep(0.3)  # storeページへのrate limiting
+
+        real_tags = set(tags) - TAG_NOISE  # ノイズタグ(Singleplayer等)を除去
+        similar_to = None
+        for _aid, prev_name, _g, prev_tags in collected_games:
+            common = real_tags & prev_tags
+            if len(common) >= args.tag_overlap_threshold:
+                similar_to = (prev_name, sorted(common))
+                break
+        if similar_to:
+            print(f"    ⚠️ タグ重なり {similar_to[1]} （{similar_to[0]}と類似）→ スキップ")
+            continue
+
         # --- レビュー収集（重い処理） ---
         try:
             reviews = collect_balanced_reviews(
@@ -235,12 +299,13 @@ def main():
             r['sentiment'] = 0
             all_reviews.append(r)
 
-        # 採用記録を更新（ジャンルカウント・使用済み集合）
-        collected_games.append((app_id, game_name, sorted(real_genres)))
+        # 採用記録を更新（ジャンルカウント・プロファイルカウント・タグ集合）
+        collected_games.append((app_id, game_name, sorted(real_genres), real_tags))
         profile_counts[real_genres] = profile_counts.get(real_genres, 0) + 1
         for g in real_genres:
             genre_counts[g] = genre_counts.get(g, 0) + 1
-        print(f"    ✅ 採用 ({len(collected_games)}/{args.n_games}) ジャンル={sorted(real_genres)}")
+        print(f"    ✅ 採用 ({len(collected_games)}/{args.n_games}) "
+              f"ジャンル={sorted(real_genres)} タグ={sorted(real_tags)}")
 
     # 3. 保存
     print(f"\n[3/3] 保存...")
@@ -272,8 +337,8 @@ def main():
     print(f"   保存先: {args.output}")
 
     print(f"\n【採用ゲーム一覧】")
-    for aid, name, genres in collected_games:
-        print(f"  - {name} ({aid}) {genres}")
+    for aid, name, genres, tags in collected_games:
+        print(f"  - {name} ({aid}) ジャンル={genres} タグ={sorted(tags)}")
 
     print(f"\n【ジャンル分布】（上限 {args.max_per_genre}）")
     for g, c in sorted(genre_counts.items(), key=lambda x: -x[1]):

--- a/scripts/collect/collect_ood_testset.py
+++ b/scripts/collect/collect_ood_testset.py
@@ -1,0 +1,204 @@
+"""
+OODテストセット収集スクリプト
+
+学習に使った7ゲーム以外の「レビューが豊富なゲーム」から、条件付きランダムで
+テストデータを収集する。自作モデルと既製汎用モデルのOOD性能比較用（Issue #21）。
+
+設計:
+- 母集団: Steam公式検索APIのレビュー数順ゲーム（=レビューが豊富なゲーム）
+- 学習7ゲームは除外
+- ランダムに選び、有効な英語レビューが P50/N50 取れるゲームのみ採用
+- 目標: 20ゲーム × (Positive 50 + Negative 50) = 2000件（balanced）
+
+再利用可能な汎用ツールとして設計（他プロジェクトでも流用可）。
+"""
+
+import os
+import sys
+import re
+import time
+import random
+import argparse
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
+
+import requests
+import pandas as pd
+
+from src.data.steam_collector import collect_balanced_reviews
+
+
+# 学習に使った7ゲーム（テストでは除外）
+TRAIN_GAME_IDS = {
+    1086940,  # Baldur's Gate 3
+    1091500,  # Cyberpunk 2077
+    413150,   # Stardew Valley
+    292030,   # The Witcher 3
+    271590,   # Grand Theft Auto V
+    730,      # Counter-Strike 2
+    570,      # Dota 2
+}
+
+
+def get_popular_games(n_pages: int = 20) -> list:
+    """
+    Steam公式の検索APIからレビュー数順の人気ゲームを取得（レビューが豊富な母集団）
+
+    Steam公式の検索結果JSONはappidを直接持たず、ロゴ画像URLに埋め込まれているため、
+    正規表現で抽出する。
+
+    Args:
+        n_pages: 取得ページ数（1ページ約25件、20ページで約500件）
+
+    Returns:
+        (app_id, game_name)のリスト（レビュー数の多い順）
+    """
+    base_url = "https://store.steampowered.com/search/results/"
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+                      'AppleWebKit/537.36 (KHTML, like Gecko) '
+                      'Chrome/120.0 Safari/537.36'
+    }
+
+    games = []
+    seen = set()
+
+    for page in range(n_pages):
+        params = {
+            'query': '',
+            'start': page * 25,
+            'count': 25,
+            'sort_by': 'Reviews_DESC',  # レビュー数の多い順
+            'category1': 998,           # 998 = ゲームのみ（DLC・ツール等を除外）
+            'json': 1,
+        }
+        response = requests.get(base_url, params=params, headers=headers, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+
+        items = data.get('items', [])
+        if not items:
+            break
+
+        for item in items:
+            logo = item.get('logo', '')
+            # ロゴURL内の /apps/<appid>/ からappidを抽出
+            match = re.search(r'/apps/(\d+)/', logo)
+            if not match:
+                continue
+            app_id = int(match.group(1))
+            if app_id in seen:
+                continue
+            seen.add(app_id)
+            games.append((app_id, item.get('name', 'Unknown')))
+
+        time.sleep(0.5)  # Steam APIへのrate limiting
+
+    return games
+
+
+def main():
+    parser = argparse.ArgumentParser(description='OODテストセット収集')
+    parser.add_argument('--n-games', type=int, default=20, help='採用するゲーム数')
+    parser.add_argument('--n-positive', type=int, default=50, help='1ゲームあたりPositive件数')
+    parser.add_argument('--n-negative', type=int, default=50, help='1ゲームあたりNegative件数')
+    parser.add_argument('--seed', type=int, default=42, help='ランダムシード')
+    parser.add_argument('--output', type=str, default='data/test/reviews_ood_2000.csv',
+                        help='出力先CSVパス')
+    args = parser.parse_args()
+
+    random.seed(args.seed)
+
+    print("=" * 60)
+    print("OODテストセット収集")
+    print("=" * 60)
+    print(f"目標: {args.n_games}ゲーム × (P{args.n_positive}+N{args.n_negative})")
+
+    # 1. 母集団取得
+    print("\n[1/3] Steam公式検索APIから人気ゲームリスト取得...")
+    popular_games = get_popular_games()
+    print(f"   取得: {len(popular_games)}ゲーム")
+
+    # 学習7ゲーム除外
+    candidates = [(aid, name) for aid, name in popular_games if aid not in TRAIN_GAME_IDS]
+    print(f"   学習7ゲーム除外後: {len(candidates)}ゲーム")
+
+    # シャッフル（ランダム化）
+    random.shuffle(candidates)
+
+    # 2. 各ゲームから条件付き収集
+    print(f"\n[2/3] 条件付き収集（P/N両方が目標数取れたゲームのみ採用）...")
+    collected_games = []
+    all_reviews = []
+
+    for app_id, game_name in candidates:
+        if len(collected_games) >= args.n_games:
+            break
+
+        print(f"\n  試行: {game_name} (appid={app_id})")
+        try:
+            reviews = collect_balanced_reviews(
+                app_id=app_id,
+                language='english',
+                n_positive=args.n_positive,
+                n_negative=args.n_negative
+            )
+        except Exception as e:
+            print(f"    ❌ エラー: {e} → スキップ")
+            continue
+
+        n_pos = len(reviews['positive'])
+        n_neg = len(reviews['negative'])
+
+        # 条件: P/N両方が目標数に達したゲームのみ採用
+        if n_pos < args.n_positive or n_neg < args.n_negative:
+            print(f"    ⚠️ 件数不足 (P{n_pos}/N{n_neg}) → スキップ")
+            continue
+
+        # 採用: メタ情報を付与
+        for r in reviews['positive'][:args.n_positive]:
+            r['game_id'] = app_id
+            r['game_name'] = game_name
+            r['sentiment'] = 1
+            all_reviews.append(r)
+        for r in reviews['negative'][:args.n_negative]:
+            r['game_id'] = app_id
+            r['game_name'] = game_name
+            r['sentiment'] = 0
+            all_reviews.append(r)
+
+        collected_games.append((app_id, game_name))
+        print(f"    ✅ 採用 ({len(collected_games)}/{args.n_games})")
+
+    # 3. 保存
+    print(f"\n[3/3] 保存...")
+    df = pd.DataFrame(all_reviews)
+    df = df.sample(frac=1, random_state=args.seed).reset_index(drop=True)
+
+    # 列の整理:
+    # - recommended（投稿者の👍/👎・生の値。sentimentの検算用に残す）
+    # - sentiment（正解ラベル 1=positive / 0=negative）
+    df = df.drop(columns=['votes_up'])
+    df = df.rename(columns={'voted_up': 'recommended'})
+    col_order = ['review_text', 'sentiment', 'recommended', 'language',
+                 'timestamp_created', 'author', 'game_id', 'game_name']
+    df = df[col_order]
+
+    os.makedirs(os.path.dirname(args.output), exist_ok=True)
+    df.to_csv(args.output, index=False, encoding='utf-8')
+
+    print("\n" + "=" * 60)
+    print("✅ 収集完了")
+    print("=" * 60)
+    print(f"   採用ゲーム: {len(collected_games)}")
+    print(f"   総レビュー: {len(df)}")
+    if len(df) > 0:
+        print(f"   Positive: {(df['sentiment']==1).sum()} / Negative: {(df['sentiment']==0).sum()}")
+    print(f"   保存先: {args.output}")
+    print(f"\n【採用ゲーム一覧】")
+    for aid, name in collected_games:
+        print(f"  - {name} ({aid})")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/collect/collect_ood_testset.py
+++ b/scripts/collect/collect_ood_testset.py
@@ -10,6 +10,11 @@ OODテストセット収集スクリプト
 - ランダムに選び、有効な英語レビューが P50/N50 取れるゲームのみ採用
 - 目標: 20ゲーム × (Positive 50 + Negative 50) = 2000件（balanced）
 
+ジャンル偏り対策（特定ジャンルがテストセットを占有しないように）:
+- ノイズタグ（Indie / Free To Play）は判定から除外（遊びの種類を表さないため）
+- (a) 除去後のジャンル集合が採用済みと完全一致なら弾く（同一プロファイルの重複防止）
+- (b) 1ジャンルあたりの所属数に上限（--max-per-genre）を設ける（メインジャンルの偏り防止）
+
 再利用可能な汎用ツールとして設計（他プロジェクトでも流用可）。
 """
 
@@ -22,10 +27,9 @@ import argparse
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
 
-import requests
 import pandas as pd
 
-from src.data.steam_collector import collect_balanced_reviews
+from src.data.steam_collector import collect_balanced_reviews, request_with_backoff
 
 
 # 学習に使った7ゲーム（テストでは除外）
@@ -37,6 +41,17 @@ TRAIN_GAME_IDS = {
     271590,   # Grand Theft Auto V
     730,      # Counter-Strike 2
     570,      # Dota 2
+}
+
+# ジャンル判定から除外するノイズタグ
+# 遊びの種類ではなく、開発規模(Indie)・価格モデル(Free To Play)・販売ステータス(Early Access)を表すため
+NOISE_TAGS = {'Indie', 'Free To Play', 'Early Access'}
+
+# Steam APIアクセス時のブラウザUA（データセンターIPからのブロック回避）
+HEADERS = {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+                  'AppleWebKit/537.36 (KHTML, like Gecko) '
+                  'Chrome/120.0 Safari/537.36'
 }
 
 
@@ -54,11 +69,6 @@ def get_popular_games(n_pages: int = 20) -> list:
         (app_id, game_name)のリスト（レビュー数の多い順）
     """
     base_url = "https://store.steampowered.com/search/results/"
-    headers = {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
-                      'AppleWebKit/537.36 (KHTML, like Gecko) '
-                      'Chrome/120.0 Safari/537.36'
-    }
 
     games = []
     seen = set()
@@ -72,8 +82,7 @@ def get_popular_games(n_pages: int = 20) -> list:
             'category1': 998,           # 998 = ゲームのみ（DLC・ツール等を除外）
             'json': 1,
         }
-        response = requests.get(base_url, params=params, headers=headers, timeout=30)
-        response.raise_for_status()
+        response = request_with_backoff(base_url, params=params, headers=HEADERS, timeout=30)
         data = response.json()
 
         items = data.get('items', [])
@@ -97,11 +106,40 @@ def get_popular_games(n_pages: int = 20) -> list:
     return games
 
 
+def get_game_genres(app_id: int) -> frozenset:
+    """
+    Steam公式のappdetails APIからゲームのジャンル集合を取得
+
+    Steamのジャンルは粗く順番も重要度順ではないため、「メインジャンル1つ」を
+    決めるのではなく集合（frozenset）として扱う。ノイズタグ（Indie等）は呼び出し側で除去する。
+
+    Args:
+        app_id: SteamのアプリID
+
+    Returns:
+        ジャンル名のfrozenset（取得失敗・ジャンル無しの場合は空のfrozenset）
+    """
+    url = "https://store.steampowered.com/api/appdetails"
+    params = {'appids': app_id, 'filters': 'genres'}
+    response = request_with_backoff(url, params=params, headers=HEADERS, timeout=30)
+    data = response.json()
+
+    entry = data.get(str(app_id), {})
+    if not entry.get('success'):
+        return frozenset()
+    genres = entry.get('data', {}).get('genres', [])
+    return frozenset(g['description'] for g in genres)
+
+
 def main():
     parser = argparse.ArgumentParser(description='OODテストセット収集')
     parser.add_argument('--n-games', type=int, default=20, help='採用するゲーム数')
     parser.add_argument('--n-positive', type=int, default=50, help='1ゲームあたりPositive件数')
     parser.add_argument('--n-negative', type=int, default=50, help='1ゲームあたりNegative件数')
+    parser.add_argument('--max-per-genre', type=int, default=4,
+                        help='1ジャンルあたりの最大採用数（ジャンル偏り防止）')
+    parser.add_argument('--max-per-profile', type=int, default=2,
+                        help='同じジャンル集合（プロファイル）あたりの最大採用数')
     parser.add_argument('--seed', type=int, default=42, help='ランダムシード')
     parser.add_argument('--output', type=str, default='data/test/reviews_ood_2000.csv',
                         help='出力先CSVパス')
@@ -127,15 +165,45 @@ def main():
     random.shuffle(candidates)
 
     # 2. 各ゲームから条件付き収集
-    print(f"\n[2/3] 条件付き収集（P/N両方が目標数取れたゲームのみ採用）...")
-    collected_games = []
+    print(f"\n[2/3] 条件付き収集（ジャンル偏り対策＋P/N両方が目標数取れたゲームのみ採用）...")
+    print(f"   ジャンル上限: 1ジャンルあたり最大{args.max_per_genre}本 / "
+          f"同一プロファイル最大{args.max_per_profile}本")
+    collected_games = []      # (app_id, name, sorted_genres) のリスト
     all_reviews = []
+    genre_counts = {}         # ジャンル名 -> 採用済み本数
+    profile_counts = {}       # ジャンル集合(frozenset) -> 採用済み本数（完全一致dedup用）
 
     for app_id, game_name in candidates:
         if len(collected_games) >= args.n_games:
             break
 
         print(f"\n  試行: {game_name} (appid={app_id})")
+
+        # --- ジャンル判定（軽い処理を先に。重いレビュー収集の前にフィルタ） ---
+        try:
+            genres = get_game_genres(app_id)
+        except Exception as e:
+            print(f"    ❌ ジャンル取得エラー: {e} → スキップ")
+            continue
+        time.sleep(0.3)  # appdetails APIへのrate limiting
+
+        real_genres = genres - NOISE_TAGS  # ノイズタグ(Indie等)を除去
+        if not real_genres:
+            print(f"    ⚠️ 有効なジャンルなし → スキップ")
+            continue
+
+        # (a) 完全一致dedup: 同じジャンルプロファイルは max_per_profile 本まで
+        if profile_counts.get(real_genres, 0) >= args.max_per_profile:
+            print(f"    ⚠️ プロファイル上限 {sorted(real_genres)} に到達 → スキップ")
+            continue
+
+        # (b) ジャンルキャップ: いずれかのジャンルが上限に達していたら弾く
+        over = sorted(g for g in real_genres if genre_counts.get(g, 0) >= args.max_per_genre)
+        if over:
+            print(f"    ⚠️ ジャンル上限 {over} に到達 → スキップ")
+            continue
+
+        # --- レビュー収集（重い処理） ---
         try:
             reviews = collect_balanced_reviews(
                 app_id=app_id,
@@ -167,8 +235,12 @@ def main():
             r['sentiment'] = 0
             all_reviews.append(r)
 
-        collected_games.append((app_id, game_name))
-        print(f"    ✅ 採用 ({len(collected_games)}/{args.n_games})")
+        # 採用記録を更新（ジャンルカウント・使用済み集合）
+        collected_games.append((app_id, game_name, sorted(real_genres)))
+        profile_counts[real_genres] = profile_counts.get(real_genres, 0) + 1
+        for g in real_genres:
+            genre_counts[g] = genre_counts.get(g, 0) + 1
+        print(f"    ✅ 採用 ({len(collected_games)}/{args.n_games}) ジャンル={sorted(real_genres)}")
 
     # 3. 保存
     print(f"\n[3/3] 保存...")
@@ -190,14 +262,22 @@ def main():
     print("\n" + "=" * 60)
     print("✅ 収集完了")
     print("=" * 60)
-    print(f"   採用ゲーム: {len(collected_games)}")
+    print(f"   採用ゲーム: {len(collected_games)} / 目標 {args.n_games}")
+    if len(collected_games) < args.n_games:
+        print(f"   ⚠️ 目標に未達。ジャンル上限(--max-per-genre={args.max_per_genre})が"
+              f"厳しすぎる可能性。下のジャンル分布を見て緩めて再走を検討してください。")
     print(f"   総レビュー: {len(df)}")
     if len(df) > 0:
         print(f"   Positive: {(df['sentiment']==1).sum()} / Negative: {(df['sentiment']==0).sum()}")
     print(f"   保存先: {args.output}")
+
     print(f"\n【採用ゲーム一覧】")
-    for aid, name in collected_games:
-        print(f"  - {name} ({aid})")
+    for aid, name, genres in collected_games:
+        print(f"  - {name} ({aid}) {genres}")
+
+    print(f"\n【ジャンル分布】（上限 {args.max_per_genre}）")
+    for g, c in sorted(genre_counts.items(), key=lambda x: -x[1]):
+        print(f"  - {g}: {c}本")
 
 
 if __name__ == '__main__':

--- a/scripts/experiments/compare_models_ood.py
+++ b/scripts/experiments/compare_models_ood.py
@@ -1,0 +1,292 @@
+"""
+自作モデル vs 既製汎用モデル(sst-2) のOOD性能比較 (Issue #21)
+
+OODテストセット（学習に使っていない20ゲーム・2000件balanced）で両モデルを評価し、
+accuracy / precision / recall / F1 / 混同行列 をグラフで比較する。
+「Steamデータでのファインチューニングに意味があったか」を未知データで検証するのが目的。
+
+ラベル整合性（重要）:
+  ラベルの対応(0/1)はベースのアーキテクチャではなく学習データのラベル付けで決まるため、
+  2モデルで一致する保証はない。整数IDで揃えず「意味ラベル」で揃える:
+  - 自作モデル: 我々が 1=positive / 0=negative で学習 → argmax をそのまま使用
+  - sst-2: pipelineが "POSITIVE"/"NEGATIVE" を文字列で返す → POSITIVE=1 / NEGATIVE=0 に変換
+  さらに、明確にポジティブな文1つで sst-2 のラベル意味を動作確認してから本番に回す。
+
+出力（data/experiments/ood_benchmark/）:
+  - metrics_comparison.png : accuracy/precision/recall/F1 のグループ棒グラフ
+  - confusion_matrices.png : 両モデルの混同行列ヒートマップ
+  - metrics.json           : 数値結果
+"""
+
+import sys
+import os
+import json
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
+
+import torch
+import numpy as np
+import pandas as pd
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+
+import matplotlib
+matplotlib.use('Agg')  # GUI不要のバックエンド
+import matplotlib.pyplot as plt
+plt.rcParams['font.sans-serif'] = ['DejaVu Sans']
+plt.rcParams['axes.unicode_minus'] = False
+
+from src.nlp.dataset import SteamReviewDataset
+from src.nlp.model import load_model
+from src.nlp.evaluation import evaluate_sentiment_model, print_evaluation_metrics
+
+# --- 設定 ---
+SELF_MODEL_DIR = 'models/best_model'                              # 自作モデル
+SST2_MODEL = 'distilbert-base-uncased-finetuned-sst-2-english'    # 既製汎用モデル
+TEST_CSV = 'data/test/reviews_ood_2000.csv'                       # OODテストセット
+OUT_DIR = 'data/experiments/ood_benchmark'
+MAX_LENGTH = 128  # 自作モデルの学習時と同じ
+
+
+def predict_self_trained(df: pd.DataFrame, device: str) -> list:
+    """自作モデルで予測（argmaxの結果が既に 1=positive/0=negative）"""
+    model, tokenizer = load_model(SELF_MODEL_DIR, device=device)
+
+    dataset = SteamReviewDataset(
+        texts=df['review_text'].tolist(),
+        labels=df['sentiment'].tolist(),  # 予測には使わないが引数上必要
+        tokenizer=tokenizer,
+        max_length=MAX_LENGTH,
+    )
+    dataloader = DataLoader(dataset, batch_size=64, shuffle=False)
+
+    model.eval()
+    preds = []
+    with torch.no_grad():
+        for batch in tqdm(dataloader, desc="自作モデル予測中"):
+            input_ids = batch['input_ids'].to(device)
+            attention_mask = batch['attention_mask'].to(device)
+            logits = model(input_ids=input_ids, attention_mask=attention_mask)
+            preds.extend(torch.argmax(logits, dim=1).cpu().tolist())
+    return preds
+
+
+def predict_sst2(df: pd.DataFrame, device: str) -> list:
+    """sst-2で予測。意味ラベル(POSITIVE/NEGATIVE)で揃え、事前に動作確認する"""
+    from transformers import pipeline
+
+    device_id = 0 if device == 'cuda' else -1
+    pipe = pipeline('sentiment-analysis', model=SST2_MODEL, device=device_id)
+
+    # 動作確認（裏取り）: 明らかにポジティブな文が POSITIVE になるか
+    sanity = pipe("This game is absolutely amazing, I love every minute of it!")[0]
+    print(f"\n[sst-2 動作確認] 明確にポジティブな文 → {sanity}")
+    assert sanity['label'] == 'POSITIVE', \
+        f"sst-2のラベル意味が想定と異なる: {sanity}（ラベル変換を見直すこと）"
+    print("  → POSITIVE と判定。ラベル意味は想定通り。\n")
+
+    texts = df['review_text'].tolist()
+    results = pipe(texts, batch_size=64, truncation=True, max_length=512)
+    # 意味ラベルで変換: POSITIVE=1 / NEGATIVE=0
+    return [1 if r['label'] == 'POSITIVE' else 0 for r in results]
+
+
+def mcnemar_test(y_true: list, pred_a: list, pred_b: list) -> dict:
+    """
+    McNemar検定: 同一テストセットで2モデルの正誤が食い違うサンプル(b,c)だけに注目し、
+    accuracyの差が統計的に有意か（＝誤差で説明できないか）を検定する。
+
+    同じデータを両モデルが見ている（対応のある比較）ため、独立2標本の検定ではなく
+    McNemar検定が正しい道具。判定が一致したサンプルは情報を持たないので無視する。
+
+    Args:
+        y_true: 正解ラベル
+        pred_a: モデルAの予測（自作）
+        pred_b: モデルBの予測（sst-2）
+
+    Returns:
+        food違いの内訳と p値（連続補正カイ二乗・正確二項）を含むdict
+    """
+    from scipy.stats import chi2 as chi2_dist, binomtest
+
+    correct_a = [p == t for p, t in zip(pred_a, y_true)]
+    correct_b = [p == t for p, t in zip(pred_b, y_true)]
+
+    both_correct = sum(1 for ca, cb in zip(correct_a, correct_b) if ca and cb)
+    both_wrong = sum(1 for ca, cb in zip(correct_a, correct_b) if not ca and not cb)
+    only_a = sum(1 for ca, cb in zip(correct_a, correct_b) if ca and not cb)  # Aだけ正解
+    only_b = sum(1 for ca, cb in zip(correct_a, correct_b) if cb and not ca)  # Bだけ正解
+
+    n = only_a + only_b  # 食い違い総数（discordant pairs）
+    if n == 0:
+        chi2_stat, p_chi2, p_exact = 0.0, 1.0, 1.0
+    else:
+        # 連続補正つきカイ二乗（df=1）
+        chi2_stat = (abs(only_a - only_b) - 1) ** 2 / n
+        p_chi2 = float(chi2_dist.sf(chi2_stat, df=1))
+        # 正確二項検定（小サンプルでも妥当）: H0のもと only_a ~ Binomial(n, 0.5)
+        p_exact = float(binomtest(min(only_a, only_b), n, 0.5).pvalue)
+
+    return {
+        'both_correct': both_correct,
+        'both_wrong': both_wrong,
+        'only_self_correct': only_a,
+        'only_sst2_correct': only_b,
+        'discordant': n,
+        'chi2': float(chi2_stat),
+        'p_chi2': p_chi2,
+        'p_exact': p_exact,
+        'significant_at_0.05': p_exact < 0.05,
+    }
+
+
+def plot_metric_comparison(m_self: dict, m_sst2: dict, mcnemar: dict, out_path: str) -> None:
+    """accuracy/precision/recall/F1 のグループ棒グラフ"""
+    metrics = ['accuracy', 'precision', 'recall', 'f1_score']
+    labels = ['Accuracy', 'Precision', 'Recall', 'F1']
+    self_vals = [m_self[k] * 100 for k in metrics]
+    sst2_vals = [m_sst2[k] * 100 for k in metrics]
+
+    x = np.arange(len(labels))
+    width = 0.35
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    bars1 = ax.bar(x - width / 2, self_vals, width, label='Self-trained (Steam)', color='#2E86DE')
+    bars2 = ax.bar(x + width / 2, sst2_vals, width, label='SST-2 (generic)', color='#E67E22')
+
+    # 棒の上に数値ラベル
+    for bars in (bars1, bars2):
+        for b in bars:
+            h = b.get_height()
+            ax.annotate(f'{h:.1f}', xy=(b.get_x() + b.get_width() / 2, h),
+                        xytext=(0, 3), textcoords='offset points',
+                        ha='center', va='bottom', fontsize=10, fontweight='bold')
+
+    ax.set_ylabel('Score (%)', fontsize=13, fontweight='bold')
+    ax.set_title('Self-trained vs SST-2 on OOD Test Set (2000 reviews / 20 unseen games)',
+                 fontsize=13, fontweight='bold', pad=15)
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels, fontsize=12)
+    ax.set_ylim(0, 110)
+    ax.legend(fontsize=11)
+    ax.grid(axis='y', alpha=0.3)
+
+    # McNemar検定の結論をグラフ上に明記（「差は意味があったか」を一目で）
+    sig = mcnemar['significant_at_0.05']
+    verdict = 'significant' if sig else 'NOT significant (within noise)'
+    acc_diff = (m_self['accuracy'] - m_sst2['accuracy']) * 100
+    note = (f"Accuracy diff: {acc_diff:+.1f}pt   |   "
+            f"McNemar test: p = {mcnemar['p_exact']:.3f}  → {verdict}")
+    ax.text(0.5, 0.97, note, transform=ax.transAxes, ha='center', va='top',
+            fontsize=11, fontweight='bold',
+            color=('#27AE60' if sig else '#C0392B'),
+            bbox=dict(boxstyle='round', facecolor='#F4F6F7', edgecolor='gray'))
+
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=200, bbox_inches='tight')
+    plt.close()
+    print(f"  保存: {out_path}")
+
+
+def plot_confusion_matrices(m_self: dict, m_sst2: dict, out_path: str) -> None:
+    """両モデルの混同行列ヒートマップ（[[TN,FP],[FN,TP]]）"""
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5))
+    tick_labels = ['Neg', 'Pos']
+
+    for ax, m, title, cmap in (
+        (axes[0], m_self, 'Self-trained (Steam)', 'Blues'),
+        (axes[1], m_sst2, 'SST-2 (generic)', 'Oranges'),
+    ):
+        cm = np.array(m['confusion_matrix'])
+        im = ax.imshow(cm, cmap=cmap)
+        # セルに件数を表示
+        for i in range(2):
+            for j in range(2):
+                ax.text(j, i, str(cm[i, j]), ha='center', va='center',
+                        fontsize=16, fontweight='bold',
+                        color='white' if cm[i, j] > cm.max() / 2 else 'black')
+        ax.set_xticks([0, 1]); ax.set_xticklabels(tick_labels, fontsize=11)
+        ax.set_yticks([0, 1]); ax.set_yticklabels(tick_labels, fontsize=11)
+        ax.set_xlabel('Predicted', fontsize=12, fontweight='bold')
+        ax.set_ylabel('Actual', fontsize=12, fontweight='bold')
+        ax.set_title(f"{title}  (Acc {m['accuracy']*100:.1f}%)", fontsize=12, fontweight='bold')
+
+    plt.suptitle('Confusion Matrix on OOD Test Set', fontsize=14, fontweight='bold')
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=200, bbox_inches='tight')
+    plt.close()
+    print(f"  保存: {out_path}")
+
+
+def main():
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    print("=" * 60)
+    print("自作モデル vs sst-2 OOD性能比較 (Issue #21)")
+    print("=" * 60)
+    print(f"  device: {device}")
+    print(f"  テストセット: {TEST_CSV}")
+
+    # 1. データ読み込み
+    df = pd.read_csv(TEST_CSV).dropna(subset=['review_text']).reset_index(drop=True)
+    y_true = df['sentiment'].tolist()
+    print(f"  件数: {len(df)} (Positive {sum(y_true)} / Negative {len(y_true) - sum(y_true)})")
+
+    # 2. 両モデルで予測
+    print("\n[1/3] 自作モデルで予測")
+    y_self = predict_self_trained(df, device)
+    print("\n[2/3] sst-2で予測")
+    y_sst2 = predict_sst2(df, device)
+
+    # 3. 評価
+    print("\n[3/3] 評価と可視化")
+    m_self = evaluate_sentiment_model(y_true, y_self)
+    m_sst2 = evaluate_sentiment_model(y_true, y_sst2)
+
+    print_evaluation_metrics(m_self, "自作モデル (Steam fine-tuned)")
+    print_evaluation_metrics(m_sst2, "sst-2 (generic)")
+
+    # McNemar検定: accuracyの差が誤差で説明できるか
+    mc = mcnemar_test(y_true, y_self, y_sst2)
+    print("\n" + "=" * 60)
+    print("McNemar検定（自作 vs sst-2 のaccuracy差は有意か）")
+    print("=" * 60)
+    print(f"  両方正解: {mc['both_correct']} / 両方不正解: {mc['both_wrong']}")
+    print(f"  自作だけ正解: {mc['only_self_correct']} / sst-2だけ正解: {mc['only_sst2_correct']}"
+          f"  (食い違い計 {mc['discordant']})")
+    print(f"  p値（正確二項検定）: {mc['p_exact']:.4f}")
+    if mc['significant_at_0.05']:
+        print("  → p < 0.05: 差は統計的に有意（ファインチューニングの効果と言える）")
+    else:
+        print("  → p ≥ 0.05: 差は有意でない＝誤差圏（このテストでは効果を主張できない）")
+
+    # 4. 可視化・保存
+    os.makedirs(OUT_DIR, exist_ok=True)
+    plot_metric_comparison(m_self, m_sst2, mc, os.path.join(OUT_DIR, 'metrics_comparison.png'))
+    plot_confusion_matrices(m_self, m_sst2, os.path.join(OUT_DIR, 'confusion_matrices.png'))
+
+    # 数値をJSONで保存（confusion_matrixはlistに変換）
+    def to_serializable(m):
+        out = {k: v for k, v in m.items() if k != 'confusion_matrix'}
+        out['confusion_matrix'] = np.array(m['confusion_matrix']).tolist()
+        return out
+
+    metrics_path = os.path.join(OUT_DIR, 'metrics.json')
+    with open(metrics_path, 'w', encoding='utf-8') as f:
+        json.dump({
+            'n_samples': len(df),
+            'self_trained': to_serializable(m_self),
+            'sst2': to_serializable(m_sst2),
+            'mcnemar': mc,
+        }, f, ensure_ascii=False, indent=2)
+    print(f"  保存: {metrics_path}")
+
+    # 5. 一言サマリ
+    diff = (m_self['accuracy'] - m_sst2['accuracy']) * 100
+    print("\n" + "=" * 60)
+    print(f"Accuracy: 自作 {m_self['accuracy']*100:.1f}% vs sst-2 {m_sst2['accuracy']*100:.1f}% "
+          f"(差 {diff:+.1f}pt)")
+    print("=" * 60)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/data/steam_collector.py
+++ b/src/data/steam_collector.py
@@ -13,6 +13,54 @@ from langdetect import DetectorFactory
 DetectorFactory.seed = 0  # 再現性のために固定
 
 
+def request_with_backoff(
+    url: str,
+    params: Optional[Dict] = None,
+    headers: Optional[Dict] = None,
+    timeout: int = 10,
+    max_retries: int = 5,
+    base_wait: float = 1.0,
+) -> requests.Response:
+    """
+    指数バックオフ付きでGETリクエストを実行
+
+    429（レート制限・bot判定）など一時的なエラー時は待ち時間を倍々に伸ばしてリトライする。
+    短い間隔でリトライを繰り返してブロックが解けないまま延々失敗し続けるのを防ぐ。
+
+    Args:
+        url: リクエストURL
+        params: クエリパラメータ
+        headers: リクエストヘッダ
+        timeout: タイムアウト秒数
+        max_retries: 最大リトライ回数
+        base_wait: バックオフの基準待ち時間（秒）。attempt回目は base_wait * 2**attempt 秒待つ。
+            429の場合はさらに10倍長く待つ（レート制限の解除には時間がかかるため）。
+
+    Returns:
+        成功時のrequests.Response
+
+    Raises:
+        requests.exceptions.RequestException: 全リトライ失敗時
+    """
+    for attempt in range(max_retries):
+        try:
+            response = requests.get(url, params=params, headers=headers, timeout=timeout)
+            response.raise_for_status()
+            return response
+        except requests.exceptions.RequestException as e:
+            # 最後の試行で失敗したら例外を投げる
+            if attempt == max_retries - 1:
+                raise
+            # HTTPステータスを取得（429=レート制限か判定）
+            status = getattr(getattr(e, 'response', None), 'status_code', None)
+            wait = base_wait * (2 ** attempt)
+            if status == 429:
+                wait *= 10  # レート制限は桁違いに長く待つ
+            print(f"    ⏳ リクエスト失敗 (status={status}, "
+                  f"{attempt + 1}/{max_retries}回目) → {wait:.0f}秒待機してリトライ")
+            time.sleep(wait)
+
+
 def is_valid_english_review(text: str, min_length: int = 20, lang_confidence: float = 0.8) -> bool:
     """
     レビューが有効な英語かどうかを判定
@@ -66,7 +114,7 @@ def get_steam_reviews(
     language: str = 'english',
     review_type: str = 'all',
     num: int = 100,
-    max_retries: int = 3
+    max_retries: int = 5
 ) -> List[Dict]:
     """
     Steam APIからレビューを収集
@@ -126,19 +174,11 @@ def get_steam_reviews(
     while len(reviews) < num:
         params['cursor'] = cursor
 
-        # retry付きAPIリクエスト
-        for attempt in range(max_retries):
-            try:
-                response = requests.get(f"{base_url}{app_id}", params=params, timeout=10)
-                response.raise_for_status()
-                data = response.json()
-                break
-            except requests.exceptions.RequestException as e:
-                if attempt == max_retries - 1:
-                    raise requests.exceptions.RequestException(
-                        f"Failed to fetch reviews after {max_retries} attempts: {e}"
-                    )
-                time.sleep(1)  # retry前の待機
+        # retry付きAPIリクエスト（429レート制限は指数バックオフで待機）
+        response = request_with_backoff(
+            f"{base_url}{app_id}", params=params, timeout=10, max_retries=max_retries
+        )
+        data = response.json()
 
         # APIレスポンス確認
         if data.get('success') != 1:


### PR DESCRIPTION
## 概要

学習に使っていない未知ゲームのレビューで、自作の感情分析モデル（Steam微調整）と既製の汎用モデル（sst-2）を比較し、**ファインチューニングに意味があったか**をOODで検証する一連の実装（Issue #21）。

## 含まれるもの

- **OODテストセット収集** (`scripts/collect/collect_ood_testset.py`)
  - 学習7ゲーム以外のレビュー豊富なゲームから条件付きランダムで収集
  - ジャンル偏り対策（所属数キャップ＋プロファイル重複制限）
  - ユーザータグの重なりで「似たゲーム」を除外（粗いgenresが取りこぼすPuzzle/Roguelike等の重複を排除）
  - 結果：20ゲーム・2000件（balanced）、全ペアが遊びとして別物
- **429指数バックオフ** (`src/data/steam_collector.py`)
  - レート制限/bot判定時に待ち時間を倍々に伸ばしてリトライ（共有のレビュー収集にも適用）
- **モデル比較** (`scripts/experiments/compare_models_ood.py`)
  - ラベル整合：意味ラベル(POSITIVE/NEGATIVE)で統一＋assert確認
  - accuracy/precision/recall/F1/混同行列＋**McNemar検定**で有意差を判定
  - 結果をグラフ（棒グラフ・混同行列）とJSONで保存

## 主要な結果

| 指標 | 自作(Steam) | sst-2(汎用) |
|---|---|---|
| Accuracy | 86.5% | 85.1% |
| F1 | 87.1% | 84.6% |

**McNemar検定 p = 0.105 → 有意差なし。** Steamファインチューニングは未知データでの正確さを有意には改善せず、変わったのは「スキル」でなく「判定の偏り」（自作=Recall寄り・皮肉に弱い）。詳細は Issue #21 のコメント参照。

## ドキュメント
Wiki に McNemar検定 / DAPT / Hard-example mining / MLM を追加。

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)
