### PR TITLE
誤分類・トピック分析の汎用化＋DAPT誤り差分分析 (#25)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -70,9 +70,10 @@ make extract-topics        # トピック抽出
 | `analyze_learning_curve.py` | Learning Curve実験結果の分析・可視化 |
 | `validate_sentiment_english.py` | 英語100件での感情分析精度検証 |
 | `bertopic_experiment.py` | BERTopicパラメータ実験 |
-| `analyze_misclassified.py` | 誤分類の抽出（モデル誤りのbaseline取得） |
-| `categorize_misclassified.py` | 誤分類のヒューリスティックタグ付け（誤りの傾向分析） |
-| `explain_misclassified.py` | 誤分類の解釈（Layer Integrated Gradientsで寄与語抽出） |
+| `analyze_misclassified.py` | 任意モデル×未知データで誤分類を抽出（`--input`/`--model`） |
+| `categorize_misclassified.py` | 誤分類のヒューリスティックタグ付け（`--input`） |
+| `diff_misclassified.py` | 2モデルの誤分類差分（fixed/broke抽出・`--before`/`--after`） |
+| `explain_misclassified.py` | 誤分類の解釈（Layer Integrated Gradientsで寄与語抽出・`--input`/`--model`） |
 | `compare_models_ood.py` | 複数モデルのOOD性能比較（accuracy/P/R/F1・McNemar） |
 
 **使用方法:**

--- a/scripts/experiments/analyze_misclassified.py
+++ b/scripts/experiments/analyze_misclassified.py
@@ -1,19 +1,17 @@
 """
-誤分類分析スクリプト
+誤分類抽出スクリプト
 
-現行の感情分析モデル（models/best_model）でreviews_10000.csv全件を予測し、
-正解ラベル（voted_up由来のlabel列）と一致しない事例を抽出する。
+指定モデル(--model)で未知データ(--input, OOD等)を予測し、誤分類した事例を抽出する。
+モデルの「汎化」の誤りを見るのが目的なので、訓練データではなく未知データに当てる。
+正解列は label / sentiment のどちらでも可（自動判定）。
 
-将来的なモデル改善のベースライン取得が目的。
-
-出力:
-    - data/experiments/sarcasm_baseline/misclassified.csv（最新のみ・上書き）
-    - data/experiments/sarcasm_baseline/summary.csv（全モデルの集計・追記）
+出力: <output-dir>/misclassified_<model>.csv ＋ summary.csv
 """
 
 import sys
 import os
 import json
+import argparse
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
 
@@ -80,18 +78,27 @@ def append_summary(summary_path: str, row: dict):
 
 
 def main():
-    print("=" * 70)
-    print("誤分類分析: reviews_10000.csv vs models/best_model")
-    print("=" * 70)
+    parser = argparse.ArgumentParser(description='誤分類抽出（任意モデル × 未知データ）')
+    parser.add_argument('--input', default='data/test/reviews_ood_2000.csv',
+                        help='評価する未知データCSV（label または sentiment 列）')
+    parser.add_argument('--model', default='models/best_model', help='モデルディレクトリ')
+    parser.add_argument('--output', default=None,
+                        help='誤分類CSV出力先（未指定なら <output-dir>/misclassified_<model>.csv）')
+    parser.add_argument('--output-dir', default='data/experiments/ood_benchmark',
+                        help='出力ディレクトリ')
+    args = parser.parse_args()
 
-    # パス設定
-    input_path = 'data/train/reviews_10000.csv'
-    model_dir = 'models/best_model'
-    output_dir = 'data/experiments/sarcasm_baseline'
-    misclassified_path = os.path.join(output_dir, 'misclassified.csv')
+    input_path = args.input
+    model_dir = args.model
+    output_dir = args.output_dir
+    os.makedirs(output_dir, exist_ok=True)
+    model_name = os.path.basename(model_dir.rstrip('/'))
+    misclassified_path = args.output or os.path.join(output_dir, f'misclassified_{model_name}.csv')
     summary_path = os.path.join(output_dir, 'summary.csv')
 
-    os.makedirs(output_dir, exist_ok=True)
+    print("=" * 70)
+    print(f"誤分類抽出: {input_path} vs {model_dir}")
+    print("=" * 70)
 
     # 1. モデルメタデータ読み込み（training_results.jsonから）
     results_path = os.path.join(model_dir, 'training_results.json')
@@ -108,9 +115,11 @@ def main():
     print(f"  学習タイムスタンプ: {training_info['timestamp']}")
     print(f"  ハイパーパラメータ: {training_info['hyperparameters']}")
 
-    # 2. データ読み込み
+    # 2. データ読み込み（正解列を label に正規化：sentimentならrename）
     df = pd.read_csv(input_path)
     df = df.dropna(subset=['review_text']).reset_index(drop=True)
+    if 'label' not in df.columns and 'sentiment' in df.columns:
+        df = df.rename(columns={'sentiment': 'label'})
     print(f"\n[2/4] データ読み込み: {len(df)}件")
 
     # 3. モデル読み込み・予測

--- a/scripts/experiments/categorize_misclassified.py
+++ b/scripts/experiments/categorize_misclassified.py
@@ -1,19 +1,15 @@
 """
 誤分類サンプルのヒューリスティックタグ付け
 
-misclassified.csvの各レビューに、該当する全パターンをタグとして付与する。
+誤分類CSV（--input）の各レビューに、該当する全パターンをタグとして付与する。
 カテゴリ排他方式と異なり、1レビューに複数タグが付与可能。
 
-入力:
-    data/experiments/sarcasm_baseline/misclassified.csv
-
-出力:
-    data/experiments/sarcasm_baseline/misclassified_tagged.csv
-    （tags列・tag_count列を追加・confidence降順でソート）
+出力（--output）: tags列・tag_count列を追加し、confidence降順でソートしたCSV。
 """
 
 import os
 import re
+import argparse
 from collections import Counter
 from itertools import combinations
 
@@ -233,8 +229,15 @@ def assign_tags(text: str) -> list[str]:
 
 
 def main():
-    input_path = 'data/experiments/sarcasm_baseline/misclassified.csv'
-    output_path = 'data/experiments/sarcasm_baseline/misclassified_tagged.csv'
+    parser = argparse.ArgumentParser(description='誤分類サンプルのヒューリスティックタグ付け')
+    parser.add_argument('--input', required=True, help='誤分類CSV（review_text列が必須）')
+    parser.add_argument('--output', default=None,
+                        help='出力先（未指定なら <input>_tagged.csv）')
+    args = parser.parse_args()
+
+    input_path = args.input
+    stem, ext = os.path.splitext(input_path)
+    output_path = args.output or f'{stem}_tagged{ext}'
 
     print('=' * 70)
     print('誤分類サンプルのヒューリスティックタグ付け')

--- a/scripts/experiments/diff_misclassified.py
+++ b/scripts/experiments/diff_misclassified.py
@@ -1,0 +1,61 @@
+"""
+2モデルの誤分類CSVを差分し、変化したレビューを抽出する
+
+同じ未知データに対する旧モデル(--before)と新モデル(--after)の誤分類CSVを比較し、
+review_text単位で集合差を取る:
+    fixed : beforeは誤り → afterは正解（新モデルが直したレビュー）
+    broke : beforeは正解 → afterは誤り（新モデルが壊したレビュー）
+
+各CSVは analyze_misclassified.py の出力（誤分類のみ・review_text/error_type列を持つ）を想定。
+出力した fixed.csv / broke.csv は categorize_misclassified.py でタグ付け分析できる。
+"""
+
+import os
+import argparse
+
+import pandas as pd
+
+
+def _fp_fn(df: pd.DataFrame) -> str:
+    """FP/FN内訳を文字列で返す"""
+    fp = (df['error_type'] == 'FP').sum()
+    fn = (df['error_type'] == 'FN').sum()
+    return f'{len(df)}件（FP {fp} / FN {fn}）'
+
+
+def main():
+    parser = argparse.ArgumentParser(description='2モデルの誤分類を差分（fixed/broke抽出）')
+    parser.add_argument('--before', required=True, help='旧モデルの誤分類CSV')
+    parser.add_argument('--after', required=True, help='新モデルの誤分類CSV')
+    parser.add_argument('--output-dir', required=True, help='fixed.csv / broke.csv の出力先')
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    before = pd.read_csv(args.before)
+    after = pd.read_csv(args.after)
+
+    before_texts = set(before['review_text'])
+    after_texts = set(after['review_text'])
+
+    # fixed: beforeで誤り かつ afterの誤りに含まれない → 新モデルが直した
+    fixed = before[~before['review_text'].isin(after_texts)].copy()
+    # broke: afterで誤り かつ beforeの誤りに含まれない → 新モデルが壊した
+    broke = after[~after['review_text'].isin(before_texts)].copy()
+
+    fixed_path = os.path.join(args.output_dir, 'fixed.csv')
+    broke_path = os.path.join(args.output_dir, 'broke.csv')
+    fixed.to_csv(fixed_path, index=False)
+    broke.to_csv(broke_path, index=False)
+
+    print('=' * 70)
+    print('誤分類の差分（before → after）')
+    print('=' * 70)
+    print(f'  before誤分類: {len(before)}件 / after誤分類: {len(after)}件')
+    print(f'  fixed（afterが直した）: {_fp_fn(fixed)} → {fixed_path}')
+    print(f'  broke（afterが壊した）: {_fp_fn(broke)} → {broke_path}')
+    print(f'  純改善: {len(fixed) - len(broke):+d}件')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/experiments/explain_misclassified.py
+++ b/scripts/experiments/explain_misclassified.py
@@ -2,14 +2,10 @@
 誤分類サンプルのモデル解釈性分析
 
 transformers-interpret（Layer Integrated Gradients）を使い、
-誤分類577件の各レビューに対してトークンごとの寄与度を算出する。
+誤分類CSV（--input）の各レビューに対してトークンごとの寄与度を算出する。
 
-入力:
-    data/experiments/sarcasm_baseline/misclassified.csv
-    models/best_model/
-
-出力:
-    data/experiments/sarcasm_baseline/explanations/
+入力: 誤分類CSV（--input・analyze_misclassified.pyの出力）＋ モデル（--model）
+出力: <出力先>/ 配下に
     ├── token_scores.csv    詳細：review_id × token × score
     ├── top_words.csv       集計：各レビューの上位5トークン
     └── summary.json        モデル全体の傾向：誤判定を引き起こす単語TOP
@@ -72,6 +68,11 @@ class HuggingFaceCompatibleWrapper(nn.Module):
 
 def parse_args():
     parser = argparse.ArgumentParser(description='誤分類サンプルの解釈性分析')
+    parser.add_argument('--input', default='data/experiments/ood_benchmark/misclassified_best_model.csv',
+                        help='誤分類CSV（analyze_misclassified.pyの出力）')
+    parser.add_argument('--model', default='models/best_model', help='モデルディレクトリ')
+    parser.add_argument('--output-dir', default=None,
+                        help='出力先（未指定なら入力と同ディレクトリのexplanations/）')
     parser.add_argument('--limit', type=int, default=None,
                         help='処理件数の上限（デフォルト全件）')
     parser.add_argument('--confidence-min', type=float, default=None,
@@ -254,9 +255,9 @@ def build_summary(
 def main():
     args = parse_args()
 
-    input_path = 'data/experiments/sarcasm_baseline/misclassified.csv'
-    model_dir = 'models/best_model'
-    output_dir = 'data/experiments/sarcasm_baseline/explanations'
+    input_path = args.input
+    model_dir = args.model
+    output_dir = args.output_dir or os.path.join(os.path.dirname(input_path), 'explanations')
     token_scores_path = os.path.join(output_dir, 'token_scores.csv')
     top_words_path = os.path.join(output_dir, 'top_words.csv')
     summary_path = os.path.join(output_dir, 'summary.json')

--- a/scripts/nlp/extract_topics.py
+++ b/scripts/nlp/extract_topics.py
@@ -1,11 +1,13 @@
 """
 トピック抽出実行スクリプト（本番用）
 
-10000件のレビューデータからBERTopicでトピックを抽出し、結果をCSVに保存する。
+レビューCSV（--input）からBERTopicでトピックを抽出し、結果をCSVに保存する。
+本番では時系列予測時に収集した未知レビューを --input に指定する。
 """
 
 import sys
 import os
+import argparse
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
 
 import pandas as pd
@@ -23,13 +25,26 @@ from src.nlp.topic import (
 def main():
     """トピック抽出のメイン実行関数"""
 
+    parser = argparse.ArgumentParser(description='BERTopicでトピック抽出')
+    parser.add_argument('--input', default='data/train/reviews_10000.csv',
+                        help='レビューCSV（review_text列が必須）')
+    parser.add_argument('--output', default=None,
+                        help='トピック付与CSV出力先（未指定なら <input>_with_topics.csv）')
+    parser.add_argument('--stats-output', default=None,
+                        help='トピック統計CSV出力先（未指定なら入力と同ディレクトリのtopic_statistics.csv）')
+    args = parser.parse_args()
+
+    input_path = args.input
+    stem, ext = os.path.splitext(input_path)
+    output_path = args.output or f'{stem}_with_topics{ext}'
+    stats_output_path = args.stats_output or os.path.join(os.path.dirname(input_path), 'topic_statistics.csv')
+
     print("=" * 80)
-    print("🔍 トピック抽出実行（10000件レビュー）")
+    print("🔍 トピック抽出実行")
     print("=" * 80)
 
     # 1. データ読み込み
     print("\n[1/5] データ読み込み")
-    input_path = 'data/train/reviews_10000.csv'
     df = pd.read_csv(input_path)
     df = df.dropna(subset=['review_text'])
     print(f"   ✓ 読み込み完了: {len(df)}件（{input_path}）")
@@ -121,7 +136,6 @@ def main():
     df_english['topic_keywords'] = df_english['topic_id'].map(topic_words_map)
 
     # 保存
-    output_path = 'data/train/reviews_10000_with_topics.csv'
     df_english.to_csv(output_path, index=False)
     print(f"\n   ✓ レビュー+トピック結果: {output_path}")
     print(f"     - カラム: review_text, topic_id, topic_probability, topic_name, topic_keywords")
@@ -154,7 +168,6 @@ def main():
     df_stats = pd.DataFrame(topic_stats)
     df_stats = df_stats.sort_values('count', ascending=False)
 
-    stats_output_path = 'data/train/topic_statistics.csv'
     df_stats.to_csv(stats_output_path, index=False)
     print(f"   ✓ トピック統計: {stats_output_path}")
     print(f"     - カラム: topic_id, topic_name, keywords, count, percentage")


### PR DESCRIPTION
## 概要
Issue #25（分析・トピック抽出が `reviews_10000` 固定）を解消し、未知データ・任意モデルで使えるよう汎用化。あわせてDAPT前後の誤分類差分を実施した。

## 変更内容
| スクリプト | 変更 |
|---|---|
| `analyze_misclassified.py` | （既存・8100c09）未知データ×任意モデルで誤分類抽出 |
| `categorize_misclassified.py` | `--input`/`--output` 引数化 |
| `extract_topics.py` | `--input`/`--output`/`--stats-output` 引数化（本番=未知レビュー対応） |
| `explain_misclassified.py` | `--input`/`--model`/`--output-dir` 引数化 |
| `diff_misclassified.py` | **新規**：2モデルの誤分類を差分し fixed/broke を抽出 |
| `scripts/README.md` | 表を更新 |

## DAPT誤り差分（OOD 2000件）
- 直した94件（FP75/FN19）／壊した48件（FP23/FN25）／純改善 **+46**
- 純改善のほぼ全てがFP削減＝「褒め言葉入りだが否定的」な対比型レビュー（否定語＋接続詞混合）の読解向上が主因
- 代償は短文でのわずかな過慎重化（副作用小）

詳細は #25 のコメント参照。

## テスト
- `diff_misclassified.py` → `categorize_misclassified.py` のパイプラインを実データで実行し、fixed/broke の集計を確認
- 汎用化した3スクリプトは `--help` でargparse動作を確認（フル実行はGPU/長時間のためユーザー実行）

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)