### PR TITLE
モデル学習シードの 42 を 0 に統一 (#24)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ train-sentiment:
 	docker-compose exec dev python scripts/nlp/train_sentiment.py \
 		--dataset data/train/reviews_10000.csv \
 		--output models/best_model_pre_dapt \
-		--seed 42 \
+		--seed 0 \
 		--batch-size 16 \
 		--epochs 10 \
 		--lr 1e-5 \
@@ -162,7 +162,7 @@ train-sentiment-dapt:
 		--dataset data/train/reviews_10000.csv \
 		--base-model models/dapt_distilbert \
 		--output models/best_model \
-		--seed 42 \
+		--seed 0 \
 		--batch-size 16 \
 		--epochs 10 \
 		--lr 1e-5 \
@@ -205,7 +205,7 @@ train-test:
 	docker-compose exec dev python scripts/nlp/train_sentiment.py \
 		--dataset data/train/reviews_10000.csv \
 		--output models/test_model \
-		--seed 42 \
+		--seed 0 \
 		--batch-size 16 \
 		--epochs 3 \
 		--lr 1e-5 \

--- a/scripts/learning_curve/learning_curve_experiment.py
+++ b/scripts/learning_curve/learning_curve_experiment.py
@@ -19,7 +19,7 @@ from scripts.nlp.train_sentiment import train_sentiment
 
 def run_learning_curve_experiment(
     data_sizes: list = [1000, 5000, 10000, 20000],
-    seeds: list = [42, 123, 456],
+    seeds: list = [0, 1, 2],
     output_dir: str = 'data/experiments/learning_curve'
 ):
     """
@@ -183,8 +183,8 @@ def main():
         '--seeds',
         type=int,
         nargs='+',
-        default=[42, 123, 456],
-        help='ランダムシード（例: --seeds 42 123 456）'
+        default=[0, 1, 2],
+        help='ランダムシード（例: --seeds 0 1 2）'
     )
     parser.add_argument(
         '--output-dir',


### PR DESCRIPTION
## 概要
`train_sentiment` のデフォルトシードを 0 にした（#27）流れで、**学習シードに残っていた 42 を 0 に統一**。マジックナンバー42をやめ連番運用（0..N-1）に揃える。

## 変更（A群：モデル学習のシードのみ）
- `Makefile`: `train-sentiment` / `train-sentiment-dapt` / `train-test` の `--seed 42` → `--seed 0`
  - 特に `train-sentiment-dapt`（best_model生成）を seed=0 に。代表モデル(seed=0)と一致させ、`make train-sentiment-dapt` が best_model を seed=42 に戻す footgun を解消
- `learning_curve_experiment.py`: `seeds` default `[42,123,456]` → `[0,1,2]`（関数・argparse・help）

## 据え置き（B群：データの来歴のため意図的に42のまま）
collect_dataset_10k/20k・preprocessing・dataset_split・collect_ood_testset の `random_state=42`。
既存データ（reviews_10000 / OOD2000）を生成した種なので、再現性のため変更しない。

## テスト
`learning_curve_experiment.py --help` で argparse 動作確認。diffはA群6行のみ。

関連: #24 / #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)